### PR TITLE
add a common main and '-target' option

### DIFF
--- a/.github/workflows/update-blockers.yml
+++ b/.github/workflows/update-blockers.yml
@@ -15,7 +15,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Create local changes
       run: |
-        go run blockers.go
+        go build
+        ./main -target blockers
     - name: Commit files
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -20,7 +20,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Create local changes
       run: |
-        go run update.go generate.go ci.go 
+        go build
+        ./main -target configs
     - name: Commit files
       run: |
         git config --local user.email "action@github.com"

--- a/blockers.go
+++ b/blockers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 
 	"github.com/google/go-github/github"
 )
@@ -93,26 +92,4 @@ func UpdateItem(item ItemInfo) (ItemInfo, error) {
 		}
 	}
 	return item, nil
-}
-
-func main() {
-	blockers, err := LoadJSON("blockers/list.json")
-	if err != nil {
-		log.Fatalf("failed to load json : %s", err)
-	}
-	log.Printf("Loaded %d blockers", len(blockers))
-	for x, blocker := range blockers {
-		log.Printf("%d/%d", x+1, len(blockers))
-
-		updated, err := UpdateItem(blocker)
-		if err != nil {
-			log.Fatalf("failed to update %+v : %s", blocker, err)
-		}
-		blockers[x] = updated
-	}
-	log.Printf("Dumping updated items")
-
-	if err := DumpJSON("blockers.json", blockers); err != nil {
-		log.Fatalf("failed to dump new json file : %s", err)
-	}
 }


### PR DESCRIPTION
the idea is to have one main, and a `-targer` option that can be "blockers|configs|all"
