### PR TITLE
make the check be case-sensitive

### DIFF
--- a/scenarios/crowdsecurity/http-bad-user-agent.yaml
+++ b/scenarios/crowdsecurity/http-bad-user-agent.yaml
@@ -3,7 +3,7 @@ format: 2.0
 #debug: true
 name: crowdsecurity/http-bad-user-agent
 description: "Detect bad user-agents"
-filter: 'evt.Meta.log_type in ["http_access-log", "http_error-log"] && any(File("bad_user_agents.txt"), {Upper(evt.Parsed.http_user_agent) contains Upper(#)})'
+filter: 'evt.Meta.log_type in ["http_access-log", "http_error-log"] && any(File("bad_user_agents.txt"), {evt.Parsed.http_user_agent contains #})'
 data:
   - source_url: https://raw.githubusercontent.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker/master/_generator_lists/bad-user-agents.list
     dest_file: bad_user_agents.txt


### PR DESCRIPTION
The wordlist is case sensitive. Making case-sensitive matches limits the risk of false positives !
