### PR TITLE
[WIP] Add core collection

### DIFF
--- a/collections/crowdsecurity/core.md
+++ b/collections/crowdsecurity/core.md
@@ -1,0 +1,2 @@
+A collection of components required for functioning of crowdsec. Contains: 
+ - crowdsecurity/syslog-logs parser 

--- a/collections/crowdsecurity/core.yaml
+++ b/collections/crowdsecurity/core.yaml
@@ -1,0 +1,6 @@
+parsers:
+  - crowdsecurity/syslog-logs
+description: "core support : syslog"
+author: sbs2001
+tags:
+  - core

--- a/collections/crowdsecurity/core.yaml
+++ b/collections/crowdsecurity/core.yaml
@@ -1,6 +1,6 @@
 parsers:
   - crowdsecurity/syslog-logs
 description: "core support : syslog"
-author: sbs2001
+author: crowdsecurity
 tags:
   - core


### PR DESCRIPTION
This fixes https://github.com/crowdsecurity/crowdsec/issues/106

To fix this, we need to  do the following :- 

- [x] Add a `core` collection  
- [x] Make the wizard always install this collection.  See https://github.com/crowdsecurity/crowdsec/pull/595
- [ ] Have checks at crowdsec, to spit warning if this collection is not installed . 


Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>