### PR TITLE
fix bug : when stable release don't have asset get zipball url instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ output.xml
 go.sum
 .vscode/
 main
+
+workspace.code-workspace

--- a/blockers.go
+++ b/blockers.go
@@ -111,7 +111,11 @@ func UpdateItem(item ItemInfo) (ItemInfo, error) {
 		item.DownloadURL = release.GetHTMLURL()
 		log.Printf("DownloadURL : %s", item.DownloadURL)
 		log.Printf("len(assets) : %d", len(release.Assets))
-		item.AssetURL = release.Assets[0].GetBrowserDownloadURL()
+		if len(release.Assets) > 0 {
+			item.AssetURL = release.Assets[0].GetBrowserDownloadURL()
+		} else {
+			item.AssetURL = *release.ZipballURL
+		}
 		item.Status = "stable"
 	} else {
 		/*if has prerelease*/


### PR DESCRIPTION
to fix that bug spotted in this [github action](https://github.com/crowdsecurity/hub/runs/1836654284?check_suite_focus=true) 