### PR TITLE
Better handling of iptables logs

### DIFF
--- a/parsers/s01-parse/crowdsecurity/iptables-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/iptables-logs.yaml
@@ -1,10 +1,10 @@
 onsuccess: next_stage
 #debug: true
-filter: "evt.Parsed.program == 'kernel'"
+filter: "evt.Parsed.program == 'kernel' and evt.Parsed.message contains 'IN=' and not (evt.Parsed.message contains 'ACCEPT')"
 name: crowdsecurity/iptables-logs
 description: "Parse iptables drop logs"
 grok:
-  pattern: \[%{DATA}\]+.*(%{WORD:action})? IN=%{WORD:int_eth} OUT= MAC=%{IP}:%{MAC} SRC=%{IP:src_ip} DST=%{IP:dst_ip} LEN=%{INT:length}.*PROTO=%{WORD:proto} SPT=%{INT:src_port} DPT=%{INT:dst_port}.*
+  pattern: IN=%{WORD:int_eth} (OUT= )?MAC=%{IP}:%{MAC} SRC=%{IP:src_ip} DST=%{IP:dst_ip} LEN=%{INT:length}.*PROTO=%{WORD:proto} SPT=%{INT:src_port} DPT=%{INT:dst_port}
   apply_on: message
 statics:
     - meta: service
@@ -13,4 +13,4 @@ statics:
       value: iptables_drop
     - meta: source_ip
       expression: "evt.Parsed.src_ip"
-  
+


### PR DESCRIPTION
This changes a few things for better iptables log handling  :
- Only parse kernel message containing IN= to prevent lots of unparsed lines in metrics
- Skip line if iptables decision is ACCEPT
- OUT= is not always present
- remove unused begining of regex, which can prevent parsing

Here are a few example of log lines which weren't parsed correctly and are now OK

From a Proxmox VE server, when we log accepted packets
```
2021-03-02T18:40:09.984Z pve-bkp kernel: 101 6 tap101i0-IN 02/Mar/2021:19:40:07 +0100 ACCEPT: IN=fwbr101i0 OUT=fwbr101i0 PHYSIN=fwln101i0 PHYSOUT=tap101i0 MAC=76:c8:d3:82:b5:d3:b6:d2:88:c3:15:e6:08:00 SRC=10.11.12.13 DST=14.15.16.17 LEN=60 TOS=0x00 PREC=0x00 TTL=56 ID=54553 PROTO=TCP SPT=36494 DPT=10051 SEQ=271997875 ACK=0 WINDOW=29200 SYN
```

Also from PVE, standard DROP. Note the absence of OUT=
```
2021-03-02T18:40:27.254Z cvn1 kernel: 0 6 PVEFW-HOST-IN 02/Mar/2021:19:40:22 +0100 policy DROP: IN=enp1s0f0 MAC=a8:1e:84:96:92:20:a0:93:51:b7:50:73:08:00 SRC=10.11.12.13 DST=14.15.16.17 LEN=40 TOS=0x00 PREC=0x00 TTL=241 ID=54321 PROTO=TCP SPT=46363 DPT=8123 SEQ=3807223242 ACK=0 WINDOW=65535 SYN
```

Linux host, using a custom log prefix (-j LOG --log-prefix 'Firewall: ')
```
2021-03-02T19:00:36.192Z stor2 kernel: Firewall: IN=em1 OUT= MAC=24:6e:96:82:7c:28:a0:93:51:b7:55:ef:08:00 SRC=10.11.12.13 DST=14.15.16.17 LEN=40 TOS=0x00 PREC=0x00 TTL=245 ID=43340 PROTO=TCP SPT=41041 DPT=34035 WINDOW=1024 RES=0x00 SYN URGP=0
```
With the above change, most of my logs are now parsed, and I do not trigger false positives with accepted-but-logged packets