### PR TITLE
nginx username can be empty

### DIFF
--- a/parsers/s01-parse/crowdsecurity/nginx-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/nginx-logs.yaml
@@ -5,7 +5,7 @@ name: crowdsecurity/nginx-logs
 description: "Parse nginx access and error logs"
 nodes:
   - grok:
-      pattern: '(%{IPORHOST:target_fqdn} )?%{IPORHOST:remote_addr} - %{NGUSER:remote_user} \[%{HTTPDATE:time_local}\] "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status} %{NUMBER:body_bytes_sent} "%{NOTDQUOTE:http_referer}" "%{NOTDQUOTE:http_user_agent}"'
+      pattern: '(%{IPORHOST:target_fqdn} )?%{IPORHOST:remote_addr} - (%{NGUSER:remote_user})? \[%{HTTPDATE:time_local}\] "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status} %{NUMBER:body_bytes_sent} "%{NOTDQUOTE:http_referer}" "%{NOTDQUOTE:http_user_agent}"'
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
Most of my nginx logs were'nt parsed correctly by crowdsec. Find out that it's because the username field can be an empty string, and the %{NGUSER} grok pattern doesn't match empty strings. So, lets make this field optional

Sample logs which weren't parsed for me, and are now OK
```
crm.internal.fws.fr 10.118.22.3 - - [03/Mar/2021:17:34:44 +0100] "POST /index.php HTTP/2.0" 200 153 "https://crm.internal.fws.fr/index.php?module=Potentials&view=Detail&record=17092&app=SALES" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.190 Safari/537.36" scheme="https"
crm.internal.fws.fr 10.118.22.3 - - [03/Mar/2021:17:34:44 +0100] "POST /index.php HTTP/2.0" 200 1669 "https://crm.internal.fws.fr/index.php?module=Potentials&view=Detail&record=17092&app=SALES" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.190 Safari/537.36" scheme="https"
crm.internal.fws.fr 10.118.22.3 - - [03/Mar/2021:17:34:45 +0100] "GET /index.php?module=Potentials&view=Detail&record=17092&app=SALES HTTP/2.0" 200 2688 "https://crm.internal.fws.fr/index.php?module=Potentials&view=Detail&record=17092&app=SALES" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.190 Safari/537.36" scheme="https"
crm.internal.fws.fr 10.118.22.3 - - [03/Mar/2021:17:34:44 +0100] "POST /index.php HTTP/2.0" 200 1669 "https://crm.internal.fws.fr/index.php?module=Potentials&view=Detail&record=17092&app=SALES" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.190 Safari/537.36" scheme="https"

```