### PR TITLE
Update sshd-logs.yaml (obfuscated-openssh-patches)

### DIFF
--- a/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
@@ -8,6 +8,7 @@ pattern_syntax:
   IPv4_WORKAROUND: (?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)
   IP_WORKAROUND: (?:%{IPV6}|%{IPv4_WORKAROUND})
   SSHD_AUTH_FAIL: 'pam_(unix|sss)\(sshd:auth\): authentication failure; logname= uid=(\d+)? euid=(\d+)? tty=ssh ruser= rhost=%{IP_WORKAROUND:sshd_client_ip} (\s)?user=%{USERNAME:sshd_invalid_user}'
+  SSHD_MAGIC_VALUE_FAILED: 'pam_(unix|sss)\(sshd:auth\): Magic value check failed \(\d*\) on obfuscated handshake from %{IP_WORKAROUND:sshd_client_ip}( port \d+)'
   SSHD_INVALID_USER: 'Invalid user\s*%{USERNAME:sshd_invalid_user}? from %{IP_WORKAROUND:sshd_client_ip}( port \d+)?'
 nodes:
   - grok:
@@ -42,6 +43,14 @@ nodes:
           expression: "evt.Parsed.sshd_invalid_user"
   - grok: 
       name: "SSHD_AUTH_FAIL"
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: ssh_failed-auth
+        - meta: target_user
+          expression: "evt.Parsed.sshd_invalid_user"
+  - grok: 
+      name: "SSHD_MAGIC_VALUE_FAILED"
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
Not sure if I created a correct pattern, could you check for correctness, please?

This pattern is a result of sshd obfuscated handshake patches [from here](https://zinglau.com/projects/ObfuscatedOpenSSHPatches.html) ([Github repo](https://github.com/zinglau/obfuscated-openssh-patches))

_A failed authentication message looks like that in auth.log:_
`Oct 10 01:48:14 username sshd[386400]: Magic value check failed (4289475479) on obfuscated handshake from 94.232.46.213 port 62730`

_Fail2ban filter string looks like that:_
`^Magic value check failed \(\d*\) on obfuscated handshake from <HOST> port`

Hope it helps! Just contact me for more info.