### PR TITLE
fix: file extensions for compressed resources

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/http-logs.yaml
+++ b/parsers/s02-enrich/crowdsecurity/http-logs.yaml
@@ -30,4 +30,4 @@ nodes:
         - parsed: file_name
           expression: evt.Parsed.file_frag + evt.Parsed.file_ext
         - parsed: static_ressource
-          expression: "Upper(evt.Parsed.file_ext) in ['.JPG', '.CSS', '.JS', '.JPEG', '.PNG', '.SVG', '.MAP', '.ICO', '.OTF', '.GIF', '.MP3', '.MP4', '.WOFF', '.WOFF2', '.TTF', '.OTF', '.EOT', '.WEBP', '.WAV'] ? 'true' : 'false'"
+          expression: "Upper(evt.Parsed.file_ext) in ['.JPG', '.CSS', '.JS', '.JPEG', '.PNG', '.SVG', '.MAP', '.ICO', '.OTF', '.GIF', '.MP3', '.MP4', '.WOFF', '.WOFF2', '.TTF', '.OTF', '.EOT', '.WEBP', '.WAV', '.GZ', '.BROTLI'] ? 'true' : 'false'"


### PR DESCRIPTION
This adds the .brotli and .gz file extension to the valid resources list.

I think it maybe better to explicitly check for css.gz and css.brotli e.g., but with the `EXT` Regex that would require a change of that. I don't understand the consequences of that, so I'll let the team decide :)

This would close #330 