### PR TITLE
Http crawl-non-statics nextcloud fix

### DIFF
--- a/scenarios/crowdsecurity/http-crawl-non_statics.md
+++ b/scenarios/crowdsecurity/http-crawl-non_statics.md
@@ -1,3 +1,3 @@
-Detect crawl (http GET) on non-static (jpg,css,js,etc.) http pages from a single ip.
+Detect crawl (http GET/HEAD) on non-static (jpg,css,js,etc.) http pages from a single ip.
 
 Leakspeed of 0.5s, capacity of 40

--- a/scenarios/crowdsecurity/http-crawl-non_statics.md
+++ b/scenarios/crowdsecurity/http-crawl-non_statics.md
@@ -1,3 +1,3 @@
-Detect crawl on non-static (jpg,css,js,etc.) http pages from a single ip.
+Detect crawl (http GET) on non-static (jpg,css,js,etc.) http pages from a single ip.
 
 Leakspeed of 0.5s, capacity of 40

--- a/scenarios/crowdsecurity/http-crawl-non_statics.yaml
+++ b/scenarios/crowdsecurity/http-crawl-non_statics.yaml
@@ -1,7 +1,7 @@
 type: leaky
 name: crowdsecurity/http-crawl-non_statics
 description: "Detect aggressive crawl from single ip"
-filter: "evt.Meta.log_type in ['http_access-log', 'http_error-log'] && evt.Parsed.static_ressource == 'false' && evt.Parsed.verb == 'GET'"
+filter: "evt.Meta.log_type in ['http_access-log', 'http_error-log'] && evt.Parsed.static_ressource == 'false' && evt.Parsed.verb in ['GET', 'HEAD']"
 distinct: "evt.Parsed.file_name"
 leakspeed: 0.5s
 capacity: 40

--- a/scenarios/crowdsecurity/http-crawl-non_statics.yaml
+++ b/scenarios/crowdsecurity/http-crawl-non_statics.yaml
@@ -1,7 +1,7 @@
 type: leaky
 name: crowdsecurity/http-crawl-non_statics
 description: "Detect aggressive crawl from single ip"
-filter: "evt.Meta.log_type in ['http_access-log', 'http_error-log'] && evt.Parsed.static_ressource == 'false'"
+filter: "evt.Meta.log_type in ['http_access-log', 'http_error-log'] && evt.Parsed.static_ressource == 'false' && evt.Parsed.verb == 'GET'"
 distinct: "evt.Parsed.file_name"
 leakspeed: 0.5s
 capacity: 40


### PR DESCRIPTION
This is a fix to solve the issue #366 

-- 
As discussed within the [discord thread](https://discord.com/channels/921520481163673640/938416827237806151),  limiting crawling to GET might be "ok" for now.
Happy to discuss additional methods like "POST / OPTIONS" but most likely they are not a crawling attack and therefore should go into another scenario.