### PR TITLE
Fix typo in nextcloud parser and collection doc

### DIFF
--- a/collections/crowdsecurity/nextcloud.md
+++ b/collections/crowdsecurity/nextcloud.md
@@ -21,9 +21,9 @@ labels:
 ---
 source: journalctl
 journalctl_filter:
-  - "SYSLOG_IDENTIFER=Nextcloud"
+  - "SYSLOG_IDENTIFIER=Nextcloud"
 labels:
-  type: Nextcloud
+  type: syslog
 ```
 - Use the filename version if you have the default [setting](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/config_sample_php_parameters.html?highlight=loglevel#logging) of logging to file
 - Use the journalctl version if you are sending logs to syslog or systemd and read the logs from journald

--- a/parsers/s01-parse/crowdsecurity/nextcloud-logs.md
+++ b/parsers/s01-parse/crowdsecurity/nextcloud-logs.md
@@ -16,7 +16,7 @@ If you are sending logs to syslog or systemd and read from journald, add:
 ---
 source: journalctl
 journalctl_filter:
-  - "SYSLOG_IDENTIFER=Nextcloud"
+  - "SYSLOG_IDENTIFIER=Nextcloud"
 labels:
-  type: Nextcloud
+  type: syslog
 ```


### PR DESCRIPTION
fix missing i in identifier in doc, use correct type for syslog/journald