### PR TITLE
synology-dsm: remove collection (loop on self)

### DIFF
--- a/.index.json
+++ b/.index.json
@@ -703,15 +703,19 @@
   },
   "crowdsecurity/synology-dsm": {
    "path": "collections/crowdsecurity/synology-dsm.yaml",
-   "version": "0.1",
+   "version": "0.2",
    "versions": {
     "0.1": {
      "digest": "cdd3722569d65100a93620001b867e7932407410b7de78b56f88c7a721f61ac6",
      "deprecated": false
+    },
+    "0.2": {
+     "digest": "6a2b5e562f0b6a4b9f1c03a05c73985e5326b7fa6d910f74a698fe182a951004",
+     "deprecated": false
     }
    },
    "long_description": "IyMgU3lub2xvZ3kgRFNNIGNvbGxlY3Rpb24KClRoaXMgU3lub2xvZ3kgRFNNIGNvbGxlY3Rpb24gc3VwcG9ydHMgOgogLSB3ZWIgYXV0aGVudGljYXRpb24gYnJ1dGVmb3JjZSBkZXRlY3Rpb24KCg==",
-   "content": "IyBTeW5vbG9neSBEU00gcGFyc2VycwpwYXJzZXJzOgogIC0gY3Jvd2RzZWN1cml0eS9zeW5vbG9neS1kc20tbG9ncwojIFN5bm9sb2d5IERTTSBjb2xsZWN0aW9ucwpjb2xsZWN0aW9uczoKICAtIGNyb3dkc2VjdXJpdHkvc3lub2xvZ3ktZHNtCiMgdGhlIGxpc3Qgb2YgcG9zdG92ZXJmbG93cyBpdCBjb250YWlucwojIHBvc3RvdmVyZmxvd3M6CiMgICAtIGNyb3dkc2VjdXJpdHkvc2VvLWJvdHMtd2hpdGVsaXN0CiMgdGhlIGxpc3Qgb2Ygc2NlbmFyaW9zIGl0IGNvbnRhaW5zCnNjZW5hcmlvczoKICAtIGNyb3dkc2VjdXJpdHkvc3lub2xvZ3ktZHNtLWJmCmRlc2NyaXB0aW9uOiAiU3lub2xvZ3kgRFNNIHdlYiBhdXRoZW50aWNhdGlvbiBzdXBwb3J0IgphdXRob3I6IGNyb3dkc2VjdXJpdHkKdGFnczoKICAtIGxpbnV4CiAgLSBzeW5vbG9neQogIC0gYnJ1dGVmb3JjZQogIC0gc2Nhbgo=",
+   "content": "IyBTeW5vbG9neSBEU00gcGFyc2VycwpwYXJzZXJzOgogIC0gY3Jvd2RzZWN1cml0eS9zeW5vbG9neS1kc20tbG9ncwojIFN5bm9sb2d5IERTTSBjb2xsZWN0aW9ucwojY29sbGVjdGlvbnM6CiMgIC0gCiMgdGhlIGxpc3Qgb2YgcG9zdG92ZXJmbG93cyBpdCBjb250YWlucwojIHBvc3RvdmVyZmxvd3M6CiMgICAtIGNyb3dkc2VjdXJpdHkvc2VvLWJvdHMtd2hpdGVsaXN0CiMgdGhlIGxpc3Qgb2Ygc2NlbmFyaW9zIGl0IGNvbnRhaW5zCnNjZW5hcmlvczoKICAtIGNyb3dkc2VjdXJpdHkvc3lub2xvZ3ktZHNtLWJmCmRlc2NyaXB0aW9uOiAiU3lub2xvZ3kgRFNNIHdlYiBhdXRoZW50aWNhdGlvbiBzdXBwb3J0IgphdXRob3I6IGNyb3dkc2VjdXJpdHkKdGFnczoKICAtIGxpbnV4CiAgLSBzeW5vbG9neQogIC0gYnJ1dGVmb3JjZQogIC0gc2Nhbgo=",
    "description": "Synology DSM web authentication support",
    "author": "crowdsecurity",
    "labels": null,

--- a/collections/crowdsecurity/synology-dsm.yaml
+++ b/collections/crowdsecurity/synology-dsm.yaml
@@ -2,8 +2,8 @@
 parsers:
   - crowdsecurity/synology-dsm-logs
 # Synology DSM collections
-collections:
-  - crowdsecurity/synology-dsm
+#collections:
+#  - 
 # the list of postoverflows it contains
 # postoverflows:
 #   - crowdsecurity/seo-bots-whitelist


### PR DESCRIPTION
collections/crowdsecurity/synology-dsm.yaml
contains a (bad) link to itself and made scenarios looping to try installing itself...

Signed-off-by: Kerma Gérald <gandalf@gk2.net>