### PR TITLE
Check for 200 response code in http-bf-wordpress_bf filter

### DIFF
--- a/scenarios/crowdsecurity/http-bf-wordpress_bf.yaml
+++ b/scenarios/crowdsecurity/http-bf-wordpress_bf.yaml
@@ -3,7 +3,7 @@ name: crowdsecurity/http-bf-wordpress_bf
 description: "detect wordpress bruteforce"
 debug: false
 # failed auth on wp-login.php returns 200
-filter: "evt.Meta.log_type == 'http_access-log' && evt.Parsed.file_name == 'wp-login.php' && evt.Parsed.verb == 'POST'"
+filter: "evt.Meta.log_type == 'http_access-log' && evt.Parsed.file_name == 'wp-login.php' && evt.Parsed.verb == 'POST' && evt.Parsed.response == '200'"
 groupby: evt.Meta.source_ip
 capacity: 5
 leakspeed: 10s

--- a/scenarios/crowdsecurity/http-bf-wordpress_bf.yaml
+++ b/scenarios/crowdsecurity/http-bf-wordpress_bf.yaml
@@ -3,7 +3,7 @@ name: crowdsecurity/http-bf-wordpress_bf
 description: "detect wordpress bruteforce"
 debug: false
 # failed auth on wp-login.php returns 200
-filter: "evt.Meta.log_type == 'http_access-log' && evt.Parsed.file_name == 'wp-login.php' && evt.Parsed.verb == 'POST' && evt.Parsed.response == '200'"
+filter: "evt.Meta.log_type == 'http_access-log' && evt.Parsed.file_name == 'wp-login.php' && evt.Parsed.verb == 'POST' && evt.Meta.http_status == '200'"
 groupby: evt.Meta.source_ip
 capacity: 5
 leakspeed: 10s


### PR DESCRIPTION
Added check for 200 response code, as normal logins can be banned with the current rules