### PR TITLE
traefik parser - add traefik_router_name to statics

### DIFF
--- a/parsers/s01-parse/crowdsecurity/traefik-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/traefik-logs.yaml
@@ -68,5 +68,5 @@ statics:
     value: http_access-log
   - target: evt.StrTime
     expression: "evt.Parsed.time_local"
-
-
+  - meta: traefik_router_name
+    expression: "evt.Parsed.traefik_router_name"


### PR DESCRIPTION
Add traefik_router_name to statics so it is possible to see which service was targeted in alerts