### PR TITLE
Update nginx-proxy-manager parser

### DIFF
--- a/parsers/s01-parse/crowdsecurity/nginx-proxy-manager-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/nginx-proxy-manager-logs.yaml
@@ -14,7 +14,7 @@ nodes:
         - target: evt.StrTime
           expression: evt.Parsed.time_local
     pattern_syntax:
-      NUM_OR_DASH: '[-|\d+]'
+      NUM_OR_DASH: '-|\d*'
   # For Default host logs
   - grok:
       pattern: '(%{IPORHOST:target_fqdn} )?%{IPORHOST:remote_addr} - (%{NGUSER:remote_user})? \[%{HTTPDATE:time_local}\] "%{WORD:verb} %{DATA:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status} %{NUMBER:body_bytes_sent} "%{NOTDQUOTE:http_referer}" "%{NOTDQUOTE:http_user_agent}"( %{NUMBER:request_length} %{NUMBER:request_time} \[%{DATA:proxy_upstream_name}\] \[%{DATA:proxy_alternative_upstream_name}\])?'

--- a/parsers/s01-parse/crowdsecurity/nginx-proxy-manager-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/nginx-proxy-manager-logs.yaml
@@ -6,7 +6,7 @@ description: "Parse Nginx Proxy Manager access and error logs"
 nodes:
   # For Proxy hosts logs
   - grok:
-      pattern: '\[%{HTTPDATE:time_local}\]( %{DATA:upstream_cache_status} %{NUMBER:upstream_status})? %{NUMBER:status} - %{WORD:verb} %{WORD:scheme} %{IPORHOST:target_fqdn} \"%{NOTDQUOTE:request}\" \[Client %{IPORHOST:remote_addr}\] \[Length %{NUMBER:body_bytes_sent}\] \[Gzip %{DATA:gzip_ratio}\]( \[Sent-to %{IPORHOST:target_server}\])? \"%{NOTDQUOTE:http_user_agent}\" \"%{NOTDQUOTE:http_referer}\"'
+      pattern: '\[%{HTTPDATE:time_local}\]( %{DATA:upstream_cache_status} %{DATA:upstream_status})? %{NUMBER:status} - %{WORD:verb} %{WORD:scheme} %{IPORHOST:target_fqdn} \"%{NOTDQUOTE:request}\" \[Client %{IPORHOST:remote_addr}\] \[Length %{NUMBER:body_bytes_sent}\] \[Gzip %{DATA:gzip_ratio}\]( \[Sent-to %{IPORHOST:target_server}\])? \"%{NOTDQUOTE:http_user_agent}\" \"%{NOTDQUOTE:http_referer}\"'
       apply_on: message
       statics:
         - meta: log_type

--- a/parsers/s01-parse/crowdsecurity/nginx-proxy-manager-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/nginx-proxy-manager-logs.yaml
@@ -6,13 +6,15 @@ description: "Parse Nginx Proxy Manager access and error logs"
 nodes:
   # For Proxy hosts logs
   - grok:
-      pattern: '\[%{HTTPDATE:time_local}\]( %{DATA:upstream_cache_status} %{DATA:upstream_status})? %{NUMBER:status} - %{WORD:verb} %{WORD:scheme} %{IPORHOST:target_fqdn} \"%{NOTDQUOTE:request}\" \[Client %{IPORHOST:remote_addr}\] \[Length %{NUMBER:body_bytes_sent}\] \[Gzip %{DATA:gzip_ratio}\]( \[Sent-to %{IPORHOST:target_server}\])? \"%{NOTDQUOTE:http_user_agent}\" \"%{NOTDQUOTE:http_referer}\"'
+      pattern: '\[%{HTTPDATE:time_local}\]( %{NUM_OR_DASH:upstream_cache_status} %{NUM_OR_DASH:upstream_status})? %{NUMBER:status} - %{WORD:verb} %{WORD:scheme} %{IPORHOST:target_fqdn} \"%{NOTDQUOTE:request}\" \[Client %{IPORHOST:remote_addr}\] \[Length %{NUMBER:body_bytes_sent}\] \[Gzip %{DATA:gzip_ratio}\]( \[Sent-to %{IPORHOST:target_server}\])? \"%{NOTDQUOTE:http_user_agent}\" \"%{NOTDQUOTE:http_referer}\"'
       apply_on: message
       statics:
         - meta: log_type
           value: http_access-log
         - target: evt.StrTime
           expression: evt.Parsed.time_local
+    pattern_syntax:
+      NUM_OR_DASH: '[-|\d+]'
   # For Default host logs
   - grok:
       pattern: '(%{IPORHOST:target_fqdn} )?%{IPORHOST:remote_addr} - (%{NGUSER:remote_user})? \[%{HTTPDATE:time_local}\] "%{WORD:verb} %{DATA:request} HTTP/%{NUMBER:http_version}" %{NUMBER:status} %{NUMBER:body_bytes_sent} "%{NOTDQUOTE:http_referer}" "%{NOTDQUOTE:http_user_agent}"( %{NUMBER:request_length} %{NUMBER:request_time} \[%{DATA:proxy_upstream_name}\] \[%{DATA:proxy_alternative_upstream_name}\])?'


### PR DESCRIPTION
The original was not parsing my logs as the upstream_status would be returned as '-'. The GROK for that was set to NUMBER, I changed it to DATA and it now parses my NPM logs again.

Example of my log which was not parsing before the change, upstream_status position is set as a '-' character.
```
[15/Apr/2022:01:33:52 -0600] - - 403 - GET https x.y.com "/vZ0zgF2G.wwwacl" [Client 1.2.3.4] [Length 171] [Gzip 3.23] [Sent-to 4.3.2.1] "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36" "-"
```