### PR TITLE
Add CloudFlare V6 addresses to CDN whitelist

### DIFF
--- a/.index.json
+++ b/.index.json
@@ -2554,7 +2554,7 @@
   "crowdsecurity/cdn-whitelist": {
    "path": "postoverflows/s01-whitelist/crowdsecurity/cdn-whitelist.yaml",
    "stage": "s01-whitelist",
-   "version": "0.3",
+   "version": "0.4",
    "versions": {
     "0.1": {
      "digest": "d1cb42fbe9f3bb37f3cfa77ef5c60ec0b17dc3703bffb0d422dc6fe9cc0eb9f5",
@@ -2567,10 +2567,14 @@
     "0.3": {
      "digest": "63c933b81052c7776deb607ed7c115b89e59a88908123e04573853201122a45a",
      "deprecated": false
+    },
+    "0.4": {
+     "digest": "626bd74a8f0dcf8e17d74238d08983693f5ac2d32b1a6ccd2d57fff02731eeaa",
+     "deprecated": false
     }
    },
    "long_description": "IyBDRE5zIHdoaXRlbGlzdAoKQ0ROcyB3aGl0ZWxpc3QgYmFzZWQgb24gZm9sbG93aW5nIGxpc3RzOgoqIGh0dHBzOi8vd3d3LmNsb3VkZmxhcmUuY29tL2lwcy12NAoKSXQgd2lsbCB3aGl0ZWxpc3Qgb3ZlcmZsb3dzIHRyaWdnZXJlZCBvbiBhbiBJUCBpbiB0aG9zZSBsaXN0cw==",
-   "content": "bmFtZTogY3Jvd2RzZWN1cml0eS9jZG4td2hpdGVsaXN0CmRlc2NyaXB0aW9uOiAiV2hpdGVsaXN0IENETiBwcm92aWRlcnMiCndoaXRlbGlzdDoKICByZWFzb246ICJDRE4gcHJvdmlkZXIiCiAgZXhwcmVzc2lvbjogCiAgICAtICJhbnkoRmlsZSgnY2xvdWRmbGFyZV9pcHMudHh0JyksIHsgSXBJblJhbmdlKGV2dC5PdmVyZmxvdy5BbGVydC5Tb3VyY2UuSVAgLCMpfSkiCmRhdGE6CiAgLSBzb3VyY2VfdXJsOiBodHRwczovL3d3dy5jbG91ZGZsYXJlLmNvbS9pcHMtdjQKICAgIGRlc3RfZmlsZTogY2xvdWRmbGFyZV9pcHMudHh0CiAgICB0eXBlOiBzdHJpbmcK",
+   "content": "bmFtZTogY3Jvd2RzZWN1cml0eS9jZG4td2hpdGVsaXN0CmRlc2NyaXB0aW9uOiAiV2hpdGVsaXN0IENETiBwcm92aWRlcnMiCndoaXRlbGlzdDoKICByZWFzb246ICJDRE4gcHJvdmlkZXIiCiAgZXhwcmVzc2lvbjogCiAgICAtICJhbnkoRmlsZSgnY2xvdWRmbGFyZV9pcHMudHh0JyksIHsgSXBJblJhbmdlKGV2dC5PdmVyZmxvdy5BbGVydC5Tb3VyY2UuSVAgLCMpfSkiCiAgICAtICJhbnkoRmlsZSgnY2xvdWRmbGFyZV9pcDZzLnR4dCcpLCB7IElwSW5SYW5nZShldnQuT3ZlcmZsb3cuQWxlcnQuU291cmNlLklQICwjKX0pIgpkYXRhOgogIC0gc291cmNlX3VybDogaHR0cHM6Ly93d3cuY2xvdWRmbGFyZS5jb20vaXBzLXY0CiAgICBkZXN0X2ZpbGU6IGNsb3VkZmxhcmVfaXBzLnR4dAogICAgdHlwZTogc3RyaW5nCiAgLSBzb3VyY2VfdXJsOiBodHRwczovL3d3dy5jbG91ZGZsYXJlLmNvbS9pcHMtdjYKICAgIGRlc3RfZmlsZTogY2xvdWRmbGFyZV9pcDZzLnR4dAogICAgdHlwZTogc3RyaW5nCg==",
    "description": "Whitelist CDN providers",
    "author": "crowdsecurity",
    "labels": null

--- a/postoverflows/s01-whitelist/crowdsecurity/cdn-whitelist.yaml
+++ b/postoverflows/s01-whitelist/crowdsecurity/cdn-whitelist.yaml
@@ -4,7 +4,11 @@ whitelist:
   reason: "CDN provider"
   expression: 
     - "any(File('cloudflare_ips.txt'), { IpInRange(evt.Overflow.Alert.Source.IP ,#)})"
+    - "any(File('cloudflare_ip6s.txt'), { IpInRange(evt.Overflow.Alert.Source.IP ,#)})"
 data:
   - source_url: https://www.cloudflare.com/ips-v4
     dest_file: cloudflare_ips.txt
+    type: string
+  - source_url: https://www.cloudflare.com/ips-v6
+    dest_file: cloudflare_ip6s.txt
     type: string


### PR DESCRIPTION
Fetched the same way as the V4 addresses. Method copied from `seo-bots-whitelist`.

Attempted to create tests for this but it seems post overflows aren't applied in `cscli hubtest` as no matter what I did I could not get it to apply even the unmodified version.