### PR TITLE
fix nginx logs pattern, add support for host:port

### DIFF
--- a/parsers/s01-parse/crowdsecurity/nginx-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/nginx-logs.yaml
@@ -12,14 +12,14 @@ nodes:
         - target: evt.StrTime
           expression: evt.Parsed.time_local
   - grok:
-        # and this one the error log
-        pattern: '(%{IPORHOST:target_fqdn} )?%{NGINXERRTIME:time} \[%{LOGLEVEL:loglevel}\] %{NONNEGINT:pid}#%{NONNEGINT:tid}: (\*%{NONNEGINT:cid} )?%{GREEDYDATA:message}, client: %{IPORHOST:remote_addr}, server: %{DATA:target_fqdn}, request: "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}", host: "%{IPORHOST}(:%{NONNEGINT})?"'
-        apply_on: message
-        statics:
-          - meta: log_type
-            value: http_error-log
-          - target: evt.StrTime
-            expression: evt.Parsed.time
+      # and this one the error log
+      pattern: '(%{IPORHOST:target_fqdn} )?%{NGINXERRTIME:time} \[%{LOGLEVEL:loglevel}\] %{NONNEGINT:pid}#%{NONNEGINT:tid}: (\*%{NONNEGINT:cid} )?%{GREEDYDATA:message}, client: %{IPORHOST:remote_addr}, server: %{DATA:target_fqdn}, request: "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}", host: "%{IPORHOST}(:%{NONNEGINT})?"'
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: http_error-log
+        - target: evt.StrTime
+          expression: evt.Parsed.time
     pattern_syntax:
       NO_DOUBLE_QUOTE: '[^"]+'
     onsuccess: next_stage

--- a/parsers/s01-parse/crowdsecurity/nginx-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/nginx-logs.yaml
@@ -13,7 +13,7 @@ nodes:
           expression: evt.Parsed.time_local
   - grok:
         # and this one the error log
-        pattern: '(%{IPORHOST:target_fqdn} )?%{NGINXERRTIME:time} \[%{LOGLEVEL:loglevel}\] %{NONNEGINT:pid}#%{NONNEGINT:tid}: (\*%{NONNEGINT:cid} )?%{GREEDYDATA:message}, client: %{IPORHOST:remote_addr}, server: %{DATA:target_fqdn}, request: "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}", host: "%{IPORHOST}"'
+        pattern: '(%{IPORHOST:target_fqdn} )?%{NGINXERRTIME:time} \[%{LOGLEVEL:loglevel}\] %{NONNEGINT:pid}#%{NONNEGINT:tid}: (\*%{NONNEGINT:cid} )?%{GREEDYDATA:message}, client: %{IPORHOST:remote_addr}, server: %{DATA:target_fqdn}, request: "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:http_version}", host: "%{IPORHOST}(:%{NONNEGINT})?"'
         apply_on: message
         statics:
           - meta: log_type


### PR DESCRIPTION
I had crowdsec logs filled with this error in production:

```
time="10-06-2022 17:37:45" level=error msg="unable to collect sources from bucket: while extracting scope from bucket crowdsecurity/nginx-req-limit-exceeded: scope is Ip but Meta[source_ip] doesn't exist"
```

Analysing the logs with:
```
crowdsec -dsn file:///var/log/nginx/lichess.error.log -type nginx -no-api
```

revealed that the parser couldn't handle this nginx log line:
```
2022/06/10 13:14:00 [error] 73917#73917: *9081828650 limiting requests, excess: 10.816 by zone "nodos_home_tier1", client: 82.64.134.116, server: lichess.org, request: "GET / HTTP/2.0", host: "lichess.org:443", referrer: "https://lichess.org/"
```

The culprit here is `host: "lichess.org:443"`.
Replacing it with just `host: "lichess.org"` fixed it.

So we need to add support for `host:port` format here.

(I replaced the user IP from the log with my own, for publication)