### PR TITLE
Update postfix & postscreen parsers for logs Mailcow/haproxy protocol

### DIFF
--- a/parsers/s01-parse/crowdsecurity/postfix-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/postfix-logs.yaml
@@ -22,7 +22,7 @@
 
 # Some of the groks used here are from https://github.com/rgevaert/grok-patterns/blob/master/grok.d/postfix_patterns
 onsuccess: next_stage
-filter: "evt.Parsed.program in ['postfix/smtpd','postfix/smtps/smtpd','postfix/submission/smtpd']"
+filter: "evt.Parsed.program in ['postfix/smtpd','postfix/smtps/smtpd','postfix/submission/smtpd', 'postfix/smtps-haproxy/smtpd', 'postfix/submission-haproxy/smtpd']"
 name: crowdsecurity/postfix-logs
 pattern_syntax:
   POSTFIX_HOSTNAME: '(%{HOSTNAME}|unknown)'

--- a/parsers/s01-parse/crowdsecurity/postscreen-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/postscreen-logs.yaml
@@ -1,5 +1,5 @@
 onsuccess: next_stage
-filter: "evt.Parsed.program == 'postfix/postscreen'"
+filter: "evt.Parsed.program in ['postfix/postscreen', 'haproxy/postscreen']"
 name: crowdsecurity/postscreen-logs
 pattern_syntax:
   POSTSCREEN_PREGREET: 'PREGREET'


### PR DESCRIPTION
This pull request adds the syslog names for haproxy protocol implementation in Mailcow.



Links to Mailcow config:

postscreen: [link](https://github.com/mailcow/mailcow-dockerized/blob/b6e3e7a658e19978bc94b96dd12fab56b11eefe9/data/conf/postfix/master.cf#L3-L5)
smtpd: [link](https://github.com/mailcow/mailcow-dockerized/blob/b6e3e7a658e19978bc94b96dd12fab56b11eefe9/data/conf/postfix/master.cf#L20-L27)
submission: [link](https://github.com/mailcow/mailcow-dockerized/blob/b6e3e7a658e19978bc94b96dd12fab56b11eefe9/data/conf/postfix/master.cf#L39-L47)


Log examples:

- Jul 24 23:50:25 test haproxy/postscreen[2953]: PREGREET 6 after 0 from [1.2.3.4]:22354: EHLO\r\n
- Jul 25 02:25:01 test haproxy/postscreen[3345]: NOQUEUE: reject: RCPT from [1.2.3.4]:61307: 550 5.7.1 Service unavailable; client [1.2.3.4] blocked using domain.org; from=<test@domain.org>, to=<domain@test.org>, proto=ESMTP, helo=<mail.domain.org>
- Jul 25 05:43:33 test postfix/submission-haproxy/smtpd[3868]: warning: unknown[1.2.3.4]: SASL PLAIN authentication failed: