### PR TITLE
sshd-logs: match "Connection closed by invalid user"

### DIFF
--- a/.tests/sshd-logs/parser.assert
+++ b/.tests/sshd-logs/parser.assert
@@ -1,5 +1,5 @@
 len(results) == 3
-len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 11
+len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 12
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Success == true
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["pid"] == "16378"
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["program"] == "sshd"
@@ -99,7 +99,16 @@ results["s00-raw"]["crowdsecurity/syslog-logs"][10].Evt.Parsed["timestamp"] == "
 results["s00-raw"]["crowdsecurity/syslog-logs"][10].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/syslog-logs"][10].Evt.Meta["machine"] == "username"
 results["s00-raw"]["crowdsecurity/syslog-logs"][10].Evt.Meta["datasource_path"] == "sshd-logs.log"
-len(results["s01-parse"]["crowdsecurity/sshd-logs"]) == 11
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Success == true
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Parsed["logsource"] == "syslog"
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Parsed["message"] == "Connection closed by invalid user root 206.81.24.125 port 45362 [preauth]"
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Parsed["pid"] == "69420"
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Parsed["program"] == "sshd"
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Parsed["timestamp"] == "Aug 03 21:39:20"
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Meta["datasource_type"] == "file"
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Meta["machine"] == "hostname"
+results["s00-raw"]["crowdsecurity/syslog-logs"][11].Evt.Meta["datasource_path"] == "sshd-logs.log"
+len(results["s01-parse"]["crowdsecurity/sshd-logs"]) == 12
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Success == true
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Evt.Parsed["message"] == "Invalid user pascal from 35.188.49.176 port 53502"
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Evt.Parsed["pid"] == "16378"
@@ -251,4 +260,17 @@ results["s01-parse"]["crowdsecurity/sshd-logs"][10].Evt.Meta["datasource_type"] 
 results["s01-parse"]["crowdsecurity/sshd-logs"][10].Evt.Meta["log_type"] == "ssh_failed-auth"
 results["s01-parse"]["crowdsecurity/sshd-logs"][10].Evt.Meta["machine"] == "username"
 results["s01-parse"]["crowdsecurity/sshd-logs"][10].Evt.Meta["service"] == "ssh"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Success == true
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Parsed["logsource"] == "syslog"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Parsed["program"] == "sshd"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Parsed["sshd_client_ip"] == "206.81.24.125"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Parsed["message"] == "Connection closed by invalid user root 206.81.24.125 port 45362 [preauth]"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Parsed["pid"] == "69420"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Parsed["timestamp"] == "Aug 03 21:39:20"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Meta["source_ip"] == "206.81.24.125"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Meta["datasource_path"] == "sshd-logs.log"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Meta["log_type"] == "ssh_failed-auth"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Meta["machine"] == "hostname"
+results["s01-parse"]["crowdsecurity/sshd-logs"][11].Evt.Meta["service"] == "ssh"
 len(results["success"][""]) == 0

--- a/.tests/sshd-logs/sshd-logs.log
+++ b/.tests/sshd-logs/sshd-logs.log
@@ -9,3 +9,4 @@ Feb 19 10:38:14 myhost sshd[3355]: Disconnected from authenticating user ftp 92.
 Feb 19 10:38:14 myhost sshd[3355]: Disconnected from totobad user ftp 92.255.85.135 port 26138 [preauth]
 Oct 10 01:48:14 username sshd[386400]: Magic value check failed (4289475479) on obfuscated handshake from 94.232.46.213 port 62730
 Oct 10 01:48:14 username sshd[386400]: Magic value check failed (4289475479) on obfuscated handshake from 94.232.46.213 port 62730
+Aug 03 21:39:20 hostname sshd[69420]: Connection closed by invalid user root 206.81.24.125 port 45362 [preauth]

--- a/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
@@ -12,7 +12,7 @@ pattern_syntax:
   SSHD_MAGIC_VALUE_FAILED: 'Magic value check failed \(\d+\) on obfuscated handshake from %{IP_WORKAROUND:sshd_client_ip} port \d+'
   SSHD_INVALID_USER: 'Invalid user\s*%{USERNAME:sshd_invalid_user}? from %{IP_WORKAROUND:sshd_client_ip}( port \d+)?'
   SSHD_INVALID_BANNER: 'banner exchange: Connection from %{IP_WORKAROUND:sshd_client_ip} port \d+: invalid format'
-  SSHD_PREAUTH_AUTHENTICATING_USER: 'Connection closed by authenticating user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
+  SSHD_PREAUTH_AUTHENTICATING_USER: 'Connection closed by (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
   #following: https://github.com/crowdsecurity/crowdsec/issues/1201 - some scanners behave differently and trigger this one
   SSHD_PREAUTH_AUTHENTICATING_USER_ALT: 'Disconnected from (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
 nodes:


### PR DESCRIPTION
For sshd configurations that have an allowlist of users, sshd might log `Connection closed by invalid user` instead of `Connection closed by authenticating user` (even for users that do exist on the system).

Log-in attempts with these users are probably still malicious attempts, so we catch and block them.

Re-use the existing `SSHD_PREAUTH_AUTHENTICATING_USER` rule for this, to be consistent with `SSHD_PREAUTH_AUTHENTICATING_USER_ALT`.