### PR TITLE
Add requested url to home assistant logs parser

### DIFF
--- a/parsers/s01-parse/crowdsecurity/home-assistant-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/home-assistant-logs.yaml
@@ -6,7 +6,7 @@ pattern_syntax:
   TIMESTAMP: '%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}'
 nodes:
   - grok:
-      pattern: "%{TIMESTAMP:time} WARNING \\(%{DATA:threadName}\\) \\[homeassistant.components.http.ban\\] Login attempt or request with invalid authentication from %{DATA:source_rdns} \\(%{IPORHOST:source_ip}\\). \\(%{GREEDYDATA:http_user_agent}\\)"
+      pattern: "%{TIMESTAMP:time} WARNING \\(%{DATA:threadName}\\) \\[homeassistant.components.http.ban\\] Login attempt or request with invalid authentication from %{DATA:source_rdns} \\(%{IPORHOST:source_ip}\\). Requested URL: '%{GREEDYDATA:url}'. \\(%{GREEDYDATA:http_user_agent}\\)"
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
On home assistant version 2022.8.2 there is a Requested URL area before the http user agent