### PR TITLE
Update uptime-kuma-logs.yaml

### DIFF
--- a/parsers/s01-parse/timokoessler/uptime-kuma-logs.yaml
+++ b/parsers/s01-parse/timokoessler/uptime-kuma-logs.yaml
@@ -4,13 +4,13 @@ name: timokoessler/uptime-kuma-logs
 description: "Parse Uptime Kuma Logs"
 nodes:
   - grok:
-      pattern: '^%{TIMESTAMP_ISO8601:timestamp} \[AUTH\] WARN: Incorrect username or password for user %{USERNAME:username}\. IP=%{IP:source_ip}$'
+      pattern: '^%{TIMESTAMP_ISO8601:timestamp} \[AUTH\] WARN: Incorrect username or password for user %{DATA:username}\. IP=%{IP:source_ip}$'
       apply_on: message
       statics:
         - meta: log_type
           value: uptime_kuma_failed_password
   - grok:
-      pattern: '^%{TIMESTAMP_ISO8601:timestamp} \[AUTH\] WARN: Invalid token provided for user %{USERNAME:username}\. IP=%{IP:source_ip}$'
+      pattern: '^%{TIMESTAMP_ISO8601:timestamp} \[AUTH\] WARN: Invalid token provided for user %{DATA:username}\. IP=%{IP:source_ip}$'
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
username can be whatever you want, which includes email addresses that break the pattern, changed USERNAME to DATA so it captures login attempts with emails as well.