### PR TITLE
Update home-assistant-logs.yaml

### DIFF
--- a/parsers/s01-parse/crowdsecurity/home-assistant-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/home-assistant-logs.yaml
@@ -6,7 +6,7 @@ pattern_syntax:
   TIMESTAMP: '%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}'
 nodes:
   - grok:
-      pattern: "%{TIMESTAMP:time} WARNING \\(%{DATA:threadName}\\) \\[homeassistant.components.http.ban\\] Login attempt or request with invalid authentication from %{DATA:source_rdns} \\(%{IPORHOST:source_ip}\\). \\(%{GREEDYDATA:http_user_agent}\\)"
+      pattern: "%{TIMESTAMP:time} WARNING \\(%{DATA:threadName}\\) \\[homeassistant.components.http.ban\\] Login attempt or request with invalid authentication from %{DATA:source_rdns} \\(%{IPORHOST:source_ip}\\). Requested URL: %{GREEDYDATA:request_uri}\\. \\(%{GREEDYDATA:http_user_agent}\\)"
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
Change in the Home Assistant log format. It includes a Request URL which breaks the current parser.

Example log: 
`
2022-09-08 13:57:48.399 WARNING (MainThread) [homeassistant.components.http.ban] Login attempt or request with invalid authentication from rtr.access.telenet.be (1.1.1.1). Requested URL: '/auth/login_flow/6f015069a8a00e1014dc59d03ba44f90'. (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36)
'
