### PR TITLE
feat: add more expressions to nextcloud-whitelist

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/nextcloud-whitelist.md
+++ b/parsers/s02-enrich/crowdsecurity/nextcloud-whitelist.md
@@ -3,9 +3,21 @@
 ### Contacts app
 Contacts has an issue with excessive 404 response codes when a user image is missing
 [Upstream issue](https://github.com/nextcloud/contacts/issues/3021)
+
 ---
 ### Photos app
 On first load the photos app calls a preview endpoint, however, if it fails to load it will trigger http-probing
+
 ---
 ### Backup app
 When loading backups for a file if those backups have been modified or deleted by (OS/USER) it can easily trigger http-probing
+
+---
+### Files app
+The `/core/preview` endpoint returns 404 if a file has no thumbnail (including files which aren't meant to, like XMLs).
+This can trigger http-probing when using the file search bar.
+
+---
+### Creating files via WebDAV
+When uploading files via WebDAV, a PROPFIND request is sent to the server, which returns 404 if the file does not
+exist. Then the file is created. Uploading more than 10 files at a time will trigger http-probing.

--- a/parsers/s02-enrich/crowdsecurity/nextcloud-whitelist.yaml
+++ b/parsers/s02-enrich/crowdsecurity/nextcloud-whitelist.yaml
@@ -7,3 +7,5 @@ whitelist:
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Parsed.file_ext == '.vcf' && evt.Parsed.http_args contains "photo" #Contacts app .vcf missing photo
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/apps/files_versions/preview' && evt.Parsed.http_args contains 'version' #Backup app missing file version
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/apps/photos/api/v1/preview' && evt.Parsed.http_args contains 'x' && evt.Parsed.http_args contains 'y' #Photo app loads all previews as small panes, but can 404
+   - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Parsed.request == '/core/preview' && evt.Parsed.http_args contains 'x=' && evt.Parsed.http_args contains 'y=' && evt.Parsed.http_args contains 'fileId=' #File preview often 404s while searching
+   - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'PROPFIND' && evt.Meta.http_path startsWith '/remote.php/webdav/' #Uploading new files via WebDAV always produces a 404


### PR DESCRIPTION
Fixes https://github.com/crowdsecurity/hub/issues/627

Hello! This PR fixes a couple more false positives when using Nextcloud:

* 404 responses when searching for files in the web interface, when Nextcloud requests preview images for files that don't have previews available
* 404 responses when uploading files via webDAV (it seems to be an intended part of the process)

It also fixes the formatting in `nextcloud-whitelist.md`.

Thank you to @LaurenceJJones for helping me with the syntax! 

You might note there are no changes to the tests for this parser. [I've posted on discord about that](https://discord.com/channels/921520481163673640/1069062913203118100/1069062913203118100): I initially updated the tests, but when I was verifying my changes and trying to work out which assertions to remove/keep, I realised that tests for whitelists don't seem to work. I considered removing them altogether, but figured I should just submit the PR and see what feedback I get.