### PR TITLE
Add grok for login attempts when dovecot uses a passed file

### DIFF
--- a/parsers/s01-parse/crowdsecurity/dovecot-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/dovecot-logs.yaml
@@ -14,10 +14,13 @@ nodes:
   - grok:
       pattern: "auth-worker\\(%{INT}\\): conn unix:auth-worker \\(pid=%{INT},uid=%{INT}\\): auth-worker<%{INT}>: pam\\(%{DATA:dovecot_user},%{IP:dovecot_remote_ip},?%{DATA}\\): (%{DATA}: )?%{DATA:dovecot_login_message}$"
       apply_on: message
+  - grok:
+      pattern: "auth: passwd-file\\(%{DATA:dovecot_user},%{IP:dovecot_remote_ip}\\): (%{DATA}: )?%{DATA:dovecot_login_message}$"
+      apply_on: message
 statics:
     - meta: log_type
       value: dovecot_logs
     - meta: source_ip
       expression: "evt.Parsed.dovecot_remote_ip"
     - meta: dovecot_login_result
-      expression: "any(['Authentication failure', 'password mismatch', 'auth failed', 'unknown user'], {evt.Parsed.dovecot_login_message contains #}) ? 'auth_failed' : ''"
+      expression: "any(['Authentication failure', 'Paqssword mismatch', 'password mismatch', 'auth failed', 'unknown user'], {evt.Parsed.dovecot_login_message contains #}) ? 'auth_failed' : ''"


### PR DESCRIPTION
This grok catches login attempts using the passed file config of dovecot. Tested on RHEL 8 with dovecot-2.3.16-3.el8.x86_64 and some 60 log lines coming from various IP addresses.

One could simplify the match part by looking for 'assword mismatch' but I didn't do that as it might look a bit weird.