### PR TITLE
change to unique custom parser variable

### DIFF
--- a/parsers/s01-parse/a1ad/meshcentral-logs.yaml
+++ b/parsers/s01-parse/a1ad/meshcentral-logs.yaml
@@ -5,11 +5,11 @@ name: a1ad/meshcentral-logs
 description: "Parse meshcentral logs"
 filter: "evt.Parsed.program == 'meshcentral'"
 pattern_syntax:
-  CUSTOMUSER: "(%{EMAILADDRESS}|%{USERNAME})"
-  CUSTOMDATE: "%{MONTH} %{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}"
+  MESHCENTRAL_CUSTOMUSER: "(%{EMAILADDRESS}|%{USERNAME})"
+  MESHCENTRAL_CUSTOMDATE: "%{MONTH} %{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}"
 nodes:
   - grok:
-      pattern: '%{CUSTOMDATE:timestamp}.*Failed password for %{CUSTOMUSER:username} from %{IP:source_ip}.*'
+      pattern: '%{MESHCENTRAL_CUSTOMDATE:timestamp}.*Failed password for %{MESHCENTRAL_CUSTOMUSER:username} from %{IP:source_ip}.*'
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
Issue found on discord by @LePresidente 

If the Pattern Syntax has the same name for multiple parsers, the first one is always used and not replaced.

So for example the first CUSTOMDATE will be reused instead of being unique to each parser
