### PR TITLE
Added match for SSH Failed authentication attempt

### DIFF
--- a/parsers/s01-parse/LePresidente/gitea-logs.yaml
+++ b/parsers/s01-parse/LePresidente/gitea-logs.yaml
@@ -13,6 +13,12 @@ nodes:
       statics:
         - meta: log_type
           value: gitea_failed_auth
+  - grok:
+      pattern: '^%{GITEA_CUSTOMDATE:timestamp}.*?Failed authentication attempt from %{IP:remote_ip}:%{NUMBER:remote_port}'
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: gitea_failed_auth
 
 statics:
     - meta: service


### PR DESCRIPTION
Added a match pattern to also pick up SSH Failed authentication attempts and not just the web failed authentication attempts.

The new grok pattern will match:
2023/02/25 20:26:14 modules/ssh/ssh.go:281:sshConnectionFailed() [W] [63fa641c-19] Failed authentication attempt from 1.2.3.4:57094