### PR TITLE
Fix nginx mail logs when using tls

### DIFF
--- a/.tests/nginx-mail-logs/nginx-mail-logs.log
+++ b/.tests/nginx-mail-logs/nginx-mail-logs.log
@@ -14,3 +14,4 @@
 2022/04/05 13:32:06 [info] 8#8: *24819 client 172.77.77.254:46610 connected to 0.0.0.0:11143
 2022/04/05 13:32:06 [info] 8#8: *24819 client logged in, client: 174.233.1.144, server: 0.0.0.0:11143, login: "admin@example.com", upstream: 172.69.69.10:143
 2022/04/05 13:32:06 [info] 8#8: *24819 proxied session done, client: 174.233.1.144, server: 0.0.0.0:11143, login: "admin@example.com", upstream: 172.69.69.10:143
+2023/04/05 21:00:42 [info] 126#126: *175063 client login failed: "Authentication credentials invalid" while in http auth state, client: 201.170.64.255 using starttls, server: 0.0.0.0:587, login: "postmaster"

--- a/.tests/nginx-mail-logs/parser.assert
+++ b/.tests/nginx-mail-logs/parser.assert
@@ -1,4 +1,4 @@
-len(results["s01-parse"]["hitech95/nginx-mail-logs"]) == 13
+len(results["s01-parse"]["hitech95/nginx-mail-logs"]) == 14
 results["s01-parse"]["hitech95/nginx-mail-logs"][0].Success == true
 results["s01-parse"]["hitech95/nginx-mail-logs"][0].Evt.Parsed["tid"] == "8"
 results["s01-parse"]["hitech95/nginx-mail-logs"][0].Evt.Parsed["time"] == "2022/04/02 15:45:23"
@@ -202,3 +202,26 @@ results["s01-parse"]["hitech95/nginx-mail-logs"][11].Evt.Meta["datasource_type"]
 results["s01-parse"]["hitech95/nginx-mail-logs"][11].Evt.Meta["log_type"] == "mail_auth"
 results["s01-parse"]["hitech95/nginx-mail-logs"][11].Evt.Meta["sub_type"] == "auth_success"
 results["s01-parse"]["hitech95/nginx-mail-logs"][12].Success == false
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Success == true
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["loglevel"] == "info"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["message"] == "client login failed: \"Authentication credentials invalid\" while in http auth state"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["time"] == "2023/04/05 21:00:42"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["username"] == "postmaster"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["cid"] == "175063"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["dest_port"] == "587"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["auth_result"] == "Authentication credentials invalid"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["pid"] == "126"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["dest_ip"] == "0.0.0.0"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["program"] == "nginx"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["tid"] == "126"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Parsed["remote_addr"] == "201.170.64.255"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["auth_result"] == "Authentication credentials invalid"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["dest_port"] == "587"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["log_type"] == "mail_auth"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["source_ip"] == "201.170.64.255"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["datasource_path"] == "nginx-mail-logs.log"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["dest_ip"] == "0.0.0.0"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["service"] == "mail"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["sub_type"] == "auth_fail"
+results["s01-parse"]["hitech95/nginx-mail-logs"][13].Evt.Meta["username"] == "postmaster"

--- a/parsers/s01-parse/hitech95/nginx-mail-logs.yaml
+++ b/parsers/s01-parse/hitech95/nginx-mail-logs.yaml
@@ -14,7 +14,7 @@ nodes:
         - target: evt.StrTime
           expression: evt.Parsed.time
   - grok:
-      pattern: '%{NGINXERRTIME:time} \[%{LOGLEVEL:loglevel}\] %{NONNEGINT:pid}#%{NONNEGINT:tid}: (\*%{NONNEGINT:cid} )?%{GREEDYDATA:message}, client: %{IPORHOST:remote_addr}, server: %{IPORHOST:dest_ip}:%{POSINT:dest_port}(, login: "%{NO_DOUBLE_QUOTE:username}")?(, upstream: %{IPORHOST:proxy_ip}:%{POSINT:proxy_port})?'
+      pattern: '%{NGINXERRTIME:time} \[%{LOGLEVEL:loglevel}\] %{NONNEGINT:pid}#%{NONNEGINT:tid}: (\*%{NONNEGINT:cid} )?%{GREEDYDATA:message}, client: %{IPORHOST:remote_addr}( using starttls,|,) server: %{IPORHOST:dest_ip}:%{POSINT:dest_port}(, login: "%{NO_DOUBLE_QUOTE:username}")?(, upstream: %{IPORHOST:proxy_ip}:%{POSINT:proxy_port})?'
       apply_on: message
     filter: "evt.Parsed.message contains 'client '"
     statics:


### PR DESCRIPTION
This fixes a bug in the nginx-mail-logs parser

When using starttls the resulting log lines look like `client: <ip> using starttls, server....`
However the original pattern could only match `client: <ip>, server....`, so any starttls logs were missed.