### PR TITLE
Whitelist zammad attachment URLs

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/zammad-whitelist.md
+++ b/parsers/s02-enrich/crowdsecurity/zammad-whitelist.md
@@ -3,3 +3,5 @@
 ### Attachments
 When downloading attachments (or the zammad-SPA fetches attachment previews), `crowdsecurity/http-crawl-non_statics` may trigger HTTP crawl non statics,
 since the Attachment-/Preview-URLs are not marked as images (ending in png,jpg etc) or PDF.
+
+When fetching attachments with argument `view=inline`, zammad may return http-status 403 (not sure why, maybe short-living session ended?): this can trigger `crowdsecurity/http-probing`.

--- a/parsers/s02-enrich/crowdsecurity/zammad-whitelist.yaml
+++ b/parsers/s02-enrich/crowdsecurity/zammad-whitelist.yaml
@@ -5,3 +5,4 @@ whitelist:
   reason: "Zammad Whitelist"
   expression:
    - evt.Meta.http_status == '200' && evt.Parsed.static_ressource == 'false' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/api/v1/ticket_attachment/'
+   - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path contains '/api/v1/ticket_attachment/' && evt.Parsed.http_args contains 'view=inline'


### PR DESCRIPTION
When downloading attachments (or the zammad-SPA fetches attachment previews), `crowdsecurity/http-crawl-non_statics` may trigger HTTP crawl non statics, since the Attachment-/Preview-URLs are not marked as images (ending in png,jpg etc) or PDF.