### PR TITLE
Add nvm postoveflow whitelist

### DIFF
--- a/postoverflows/s01-whitelist/crowdsecurity/auditd-nvm-whitelist-process.md
+++ b/postoverflows/s01-whitelist/crowdsecurity/auditd-nvm-whitelist-process.md
@@ -1,0 +1,5 @@
+## nvm whitelist process
+
+Since node version manager keep `node` and `npm` within a directory `.nvm` in the user's home directory, it will trigger our suspicious process detection. This postoverflow will whitelist the process `node` when they are executed from the `.nvm` directory.
+
+This postoverflow is not supplied by default with auditd collection as you may not use nvm.

--- a/postoverflows/s01-whitelist/crowdsecurity/auditd-nvm-whitelist-process.yaml
+++ b/postoverflows/s01-whitelist/crowdsecurity/auditd-nvm-whitelist-process.yaml
@@ -1,0 +1,7 @@
+name: crowdsecurity/auditd-nvm-whitelist-process
+description: "Whitelist nvm process that are false-positives prone"
+whitelist:
+  reason: "node version manager"
+  expression: 
+    - |
+    all(evt.Overflow.Alert.Events, {.GetMeta('exe') matches '\\.nvm\\/versions\\/node\\/v(\\d+)\\.(\\d+)\\.(\\d+)\\/bin\\/node$'})


### PR DESCRIPTION
We may want to extend the format to only allow `/home/.*/.nvm/` instead of allowing anything with right convention.