### PR TITLE
Update rDNS filter to check if scope is Ip

### DIFF
--- a/postoverflows/s00-enrich/crowdsecurity/rdns.yaml
+++ b/postoverflows/s00-enrich/crowdsecurity/rdns.yaml
@@ -1,5 +1,5 @@
 onsuccess: next_stage
-filter: "evt.Overflow.Alert.Remediation == true"
+filter: "evt.Overflow.Alert.Remediation == true && evt.Overflow.Alert.GetScope() == 'Ip'"
 name: crowdsecurity/rdns
 description: "Lookup the DNS associated to the source IP only for overflows"
 statics:


### PR DESCRIPTION
Cause we have auditd and everything now we should be a little bit more specific incase a user creates a scenario that is not a Ip based remediation is true.

Edit: checking enricher code it will fail, but lets save us time by bypassing the filter