### PR TITLE
fix(paperless-ngx): Remove ^ from the patterns to allow container log…

### DIFF
--- a/parsers/s01-parse/andreasbrett/paperless-ngx-logs.yaml
+++ b/parsers/s01-parse/andreasbrett/paperless-ngx-logs.yaml
@@ -7,7 +7,7 @@ pattern_syntax:
 nodes:
     - grok:
           # Paperless-ngx v1.14.0 to v1.16.5
-          pattern: '^\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}\.`$'
+          pattern: '\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}\.`$'
           apply_on: message
           statics:
               - meta: log_type
@@ -16,7 +16,7 @@ nodes:
                 expression: evt.Parsed.username
     - grok:
           # Paperless-ngx v1.16.6+
-          pattern: '^\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}`\.$'
+          pattern: '\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}`\.$'
           apply_on: message
           statics:
               - meta: log_type

--- a/parsers/s01-parse/andreasbrett/paperless-ngx-logs.yaml
+++ b/parsers/s01-parse/andreasbrett/paperless-ngx-logs.yaml
@@ -7,7 +7,7 @@ pattern_syntax:
 nodes:
     - grok:
           # Paperless-ngx v1.14.0 to v1.16.5
-          pattern: '\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}\.`$'
+          pattern: '\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}\.`'
           apply_on: message
           statics:
               - meta: log_type
@@ -16,7 +16,7 @@ nodes:
                 expression: evt.Parsed.username
     - grok:
           # Paperless-ngx v1.16.6+
-          pattern: '\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}`\.$'
+          pattern: '\[%{DATE_YMD:date} %{TIME:time}\] \[INFO\] \[paperless\.auth\] Login failed for user `%{USERNAME:username}` from (private )?IP `%{IP:source_ip}`\.'
           apply_on: message
           statics:
               - meta: log_type


### PR DESCRIPTION
First of all - Thanks for the great work ! 

It seems like we have to remove the start of the line matching filter to allow container logs to be parsed.