### PR TITLE
fix(authelia): Remove ^ from the patterns to allow container log parsing

### DIFF
--- a/parsers/s01-parse/LePresidente/authelia-logs.yaml
+++ b/parsers/s01-parse/LePresidente/authelia-logs.yaml
@@ -4,9 +4,9 @@ name: LePresidente/authelia-logs
 filter: "evt.Parsed.program == 'authelia'"
 description: "Parse Authelia logs"
 pattern_syntax:  
-  AUTHELIA_BAD_AUTH: 'Unsuccessful 1FA authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\'
-  AUTHELIA_BAD_DUO: 'Unsuccessful Duo authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\'
-  AUTHELIA_BAD_TOTP: 'Unsuccessful TOTP authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\'
+  AUTHELIA_BAD_AUTH: 'Unsuccessful 1FA authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\S'
+  AUTHELIA_BAD_DUO: 'Unsuccessful Duo authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\S'
+  AUTHELIA_BAD_TOTP: 'Unsuccessful TOTP authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\S'
   AUTHELIA_CLF_BADAUTH: 'time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_AUTH}.*?remote_ip=%{IP:remote_ip}'
   AUTHELIA_CLF_DUO: 'time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_DUO}.*?remote_ip=%{IP:remote_ip}'
   AUTHELIA_CLF_TOTP: 'time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_TOTP}.*?remote_ip=%{IP:remote_ip}'

--- a/parsers/s01-parse/LePresidente/authelia-logs.yaml
+++ b/parsers/s01-parse/LePresidente/authelia-logs.yaml
@@ -4,12 +4,12 @@ name: LePresidente/authelia-logs
 filter: "evt.Parsed.program == 'authelia'"
 description: "Parse Authelia logs"
 pattern_syntax:  
-  AUTHELIA_BAD_AUTH: 'Unsuccessful 1FA authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\S'
-  AUTHELIA_BAD_DUO: 'Unsuccessful Duo authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\S'
-  AUTHELIA_BAD_TOTP: 'Unsuccessful TOTP authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\S'
-  AUTHELIA_CLF_BADAUTH: '^time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_AUTH}.*?remote_ip=%{IP:remote_ip}'
-  AUTHELIA_CLF_DUO: '^time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_DUO}.*?remote_ip=%{IP:remote_ip}'
-  AUTHELIA_CLF_TOTP: '^time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_TOTP}.*?remote_ip=%{IP:remote_ip}'
+  AUTHELIA_BAD_AUTH: 'Unsuccessful 1FA authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\'
+  AUTHELIA_BAD_DUO: 'Unsuccessful Duo authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\'
+  AUTHELIA_BAD_TOTP: 'Unsuccessful TOTP authentication attempt by user \S(%{EMAILADDRESS:email}|%{USERNAME:username})\'
+  AUTHELIA_CLF_BADAUTH: 'time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_AUTH}.*?remote_ip=%{IP:remote_ip}'
+  AUTHELIA_CLF_DUO: 'time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_DUO}.*?remote_ip=%{IP:remote_ip}'
+  AUTHELIA_CLF_TOTP: 'time="%{RFC3339:timestamp}".*?%{AUTHELIA_BAD_TOTP}.*?remote_ip=%{IP:remote_ip}'
 nodes:
   - grok:
       name: "AUTHELIA_CLF_BADAUTH"


### PR DESCRIPTION
First of all - Thanks for the great work !

It seems like we have to remove the start/end of the line matching filter to allow container logs to be parsed.

Similar to https://github.com/crowdsecurity/hub/pull/818
