### PR TITLE
Add journalctl example to iptables

### DIFF
--- a/collections/crowdsecurity/iptables.md
+++ b/collections/crowdsecurity/iptables.md
@@ -15,6 +15,16 @@ labels:
   type: syslog
 ```
 
+Debian 12 example (without rsyslog)
+
+```yaml
+source: journalctl
+journalctl_filter:
+ - "-k"
+labels:
+  type: syslog
+```
+
 notes :
  -  Depending on your distribution/OS, paths to log files might change
  -  Only relevant if you are manually installing collection


### PR DESCRIPTION
It wasnt clear to a community member how to achieve reading kernal message without rsyslog.

Add example to collection.