### PR TITLE
Improve cache invalidation job

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Invalidate cache
         run: |
           create_invalidation() {
-            aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths "$1"
+            #$1 is not quotted on purpose, so it can be expanded to multiple arguments
+            aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths $1
           }
           PATHS="/${{ env.version }}/.index.json"
           IFS=',' read -ra FILE <<< "${{ env.changed_files }}"

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -53,11 +53,6 @@ jobs:
   invalidate-cache:
     runs-on: ubuntu-latest
     needs: build
-    #Only invalidate cache on master or vX branches
-    #Branches that don't match this pattern are only used for dev, so we can manually invalidate if needed
-    #We should avoid naming dev branches with something starting with v :D
-    #if: |
-    #   startsWith('refs/heads/v', github.ref) || github.ref == 'refs/heads/master'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -56,8 +56,8 @@ jobs:
     #Only invalidate cache on master or vX branches
     #Branches that don't match this pattern are only used for dev, so we can manually invalidate if needed
     #We should avoid naming dev branches with something starting with v :D
-    if: |
-      startsWith('refs/heads/v', github.ref) || github.ref == 'refs/heads/master'
+    #if: |
+    #   startsWith('refs/heads/v', github.ref) || github.ref == 'refs/heads/master'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -77,8 +77,16 @@ jobs:
           echo "changed_files=${changed_files}" >> $GITHUB_ENV
       - name: Invalidate cache
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths "/${{ env.version }}/.index.json"
+          create_invalidation() {
+            aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths "$1"
+          }
+          PATHS="/${{ env.version }}/.index.json"
           IFS=',' read -ra FILE <<< "${{ env.changed_files }}"
           for i in "${FILE[@]}"; do
-            aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths "/${{ env.version }}/$i"
+            PATHS="$PATHS /${{ env.version }}/$i"
+          done
+          echo "Invalidating paths: $PATHS"
+          for ((i=0; i < 3; i++)); do
+            create_invalidation "$PATHS" && break || echo "Invalidation failed, retrying in 5 seconds..."
+            sleep 5
           done

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -64,11 +64,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.CF_AWS_ROLE }}
           role-session-name: github-action
           aws-region: eu-west-1
+          mask-aws-account-id: true
       - name: Get branch name
         run: echo "version=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Get changed files


### PR DESCRIPTION
 - make only one query to AWS API to invalidate all changed files
 - Retry up to 3 times
 - Upgrade configure-aws-credentials action to v4
 - Always run the invalidation, even on dev branches