### PR TITLE
Add -output and -status-code options

### DIFF
--- a/waf-check/config.go
+++ b/waf-check/config.go
@@ -25,8 +25,9 @@ func LoadConfig() (Config, error) {
 
 	configFile := flag.String("config", "./config.yaml", "Configuration file")
 	datasetFolder := flag.String("dataset", "", "Path to dataset. Priority over configuration file")
+	outputFolder := flag.String("output", "", "Path to fail directory. Priority over configuration file")
 	batch := flag.Bool("batch", false, "Batch mode")
-	download := flag.Bool("download", false, "Download dataset")
+	download := flag.Bool("download", false, "Download dataset. Priority over configuration file")
 	dirCount := flag.Int("dir-count", 3, "Split batch")
 	flag.Parse()
 
@@ -44,6 +45,10 @@ func LoadConfig() (Config, error) {
 
 	if *datasetFolder != "" {
 		config.DatasetFolder = *datasetFolder
+	}
+
+	if *outputFolder != "" {
+		config.OutputFolder = *outputFolder
 	}
 
 	if *download {

--- a/waf-check/config.go
+++ b/waf-check/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 
 	"gopkg.in/yaml.v2"
@@ -15,6 +16,7 @@ type Config struct {
 	NbRoutines      int    `yaml:"nb_routines"`
 	OutputFolder    string `yaml:"output_folder"`
 	DownloadDataset bool   `yaml:"download_dataset"`
+	statusCode      int    `yaml:"-"`
 	path            string `yaml:"-"`
 	batch           bool   `yaml:"-"`
 	dirCount        int    `yaml:"-"`
@@ -29,6 +31,7 @@ func LoadConfig() (Config, error) {
 	batch := flag.Bool("batch", false, "Batch mode")
 	download := flag.Bool("download", false, "Download dataset. Priority over configuration file")
 	dirCount := flag.Int("dir-count", 3, "Split batch")
+	statusCode := flag.Int("status-code", http.StatusForbidden, "Expected status code")
 	flag.Parse()
 
 	config.path = *configFile
@@ -43,12 +46,12 @@ func LoadConfig() (Config, error) {
 		return config, fmt.Errorf("error unmarshaling YAML: %s", err)
 	}
 
-	if *datasetFolder != "" {
-		config.DatasetFolder = *datasetFolder
-	}
-
 	if *outputFolder != "" {
 		config.OutputFolder = *outputFolder
+	}
+
+	if *datasetFolder != "" {
+		config.DatasetFolder = *datasetFolder
 	}
 
 	if *download {
@@ -57,6 +60,7 @@ func LoadConfig() (Config, error) {
 
 	config.batch = *batch
 	config.dirCount = *dirCount
+	config.statusCode = *statusCode
 
 	return config, nil
 }

--- a/waf-check/manager.go
+++ b/waf-check/manager.go
@@ -18,6 +18,7 @@ type Manager struct {
 	WafURL      string
 	NbWorker    int
 	filesList   []string
+	statusCode  int
 }
 
 type FailTest struct {
@@ -67,7 +68,7 @@ func (m *Manager) processFile(file string) {
 			log.Fatalf("error doing request from file '%s' to '%s': %s", file, request.FullURL, err)
 		}
 
-		if resp.StatusCode == http.StatusForbidden {
+		if resp.StatusCode == m.statusCode {
 			readErr := ""
 			responseBody, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -105,6 +106,7 @@ func NewManager(config Config, filesList []string) Manager {
 		filesChan:   make(chan string),
 		resultsChan: make(chan Result, len(filesList)),
 		filesList:   filesList,
+		statusCode:  config.statusCode,
 	}
 }
 

--- a/waf-check/result.go
+++ b/waf-check/result.go
@@ -19,9 +19,11 @@ func GetResult(resultsChan chan Result, outputFolder string) error {
 		totalTestFail += len(result.FailedTests)
 
 		resultCpt += 1
+
+		percentage := (100.0 * float32(len(result.FailedTests))) / float32(result.DoneTests)
 		fmt.Printf("'%s' result:\n", result.Filename)
 		fmt.Printf("  - %d/%d tests done\n", result.DoneTests, result.TotalTests)
-		fmt.Printf("  - %d/%d tests failed\n", len(result.FailedTests), result.DoneTests)
+		fmt.Printf("  - %d/%d tests failed (%.2f %%)\n", len(result.FailedTests), result.DoneTests, percentage)
 		if len(result.FailedTests) > 0 {
 			filename := filepath.Base(result.Filename)
 			failedTestFile := fmt.Sprintf("failed_%s", filename)
@@ -42,10 +44,11 @@ func GetResult(resultsChan chan Result, outputFolder string) error {
 	}
 	close(resultsChan)
 
+	percentageTotal := (100.0 * float32(totalTestFail)) / float32(totalTestRun)
 	fmt.Println("Result:")
 	fmt.Printf("  - Total file: %d\n", totalFileRun)
 	fmt.Printf("  - Total test: %d\n", totalTestRun)
-	fmt.Printf("  - Total fail: %d\n", totalTestFail)
+	fmt.Printf("  - Total fail: %d (%.2f %%)\n", totalTestFail, percentageTotal)
 
 	if totalTestFail > 0 {
 		return fmt.Errorf("%d tests have failed", totalTestFail)


### PR DESCRIPTION
Add `-output` & `-status-code` options and fixes a command line help message.