### PR TITLE
fix formatting in miniflux collection readme

### DIFF
--- a/collections/jbowdre/miniflux.md
+++ b/collections/jbowdre/miniflux.md
@@ -2,9 +2,6 @@ A collection to defend [Miniflux](https://miniflux.app/) instance against common
  - Miniflux parser
  - Miniflux bruteforce detection
 
-> [!NOTE]
-> Miniflux doesn't write timestamps in logs by default. You must set `LOG_DATE_TIME=1` to enable timestamps.
-
 ## Acquisition template
 
 Example acquisition for this collection :
@@ -17,3 +14,6 @@ container_name:
 labels:
   type: miniflux
 ```
+
+Note:
+- Miniflux doesn't write timestamps in logs by default. You must set `LOG_DATE_TIME=1` to enable timestamps.


### PR DESCRIPTION
Github-flavored > [!NOTE] alerts don't render correctly in the Hub.

This change fixes the note formatting and moves the note below the aquisition example to more closely match the layout used in other collections.