### PR TITLE
Fix ub cache invalidation

### DIFF
--- a/.github/workflows/appsec_vpatch_lint.yaml
+++ b/.github/workflows/appsec_vpatch_lint.yaml
@@ -16,6 +16,8 @@ jobs:
         with:
           python-version: "3.10"
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Get changed files
         run: |
           changed_files=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA | tr '\n' ',' | sed 's/,$/\n/')

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -78,17 +78,17 @@ jobs:
           echo "changed_files=${changed_files}" >> $GITHUB_ENV
       - name: Invalidate cache
         run: |
-          # create_invalidation() {
-          #   #$1 is not quotted on purpose, so it can be expanded to multiple arguments
-          #   aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths $1
-          # }
-          # PATHS="/${{ env.version }}/.index.json"
-          # IFS=',' read -ra FILE <<< "${{ env.changed_files }}"
-          # for i in "${FILE[@]}"; do
-          #   PATHS="$PATHS /${{ env.version }}/$i"
-          # done
-          # echo "Invalidating paths: $PATHS"
+          create_invalidation() {
+            #$1 is not quotted on purpose, so it can be expanded to multiple arguments
+            aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths $1
+          }
+          PATHS="/${{ env.version }}/.index.json"
+          IFS=',' read -ra FILE <<< "${{ env.changed_files }}"
+          for i in "${FILE[@]}"; do
+            PATHS="$PATHS /${{ env.version }}/$i"
+          done
+          echo "Invalidating paths: $PATHS"
           for ((i=0; i < 3; i++)); do
-            aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths '/*' && break || echo "Invalidation failed, retrying in 5 seconds..."
+            create_invalidation "$PATHS" && break || echo "Invalidation failed, retrying in 5 seconds..."
             sleep 5
           done

--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -61,6 +61,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/update_taxonomy.yaml
+++ b/.github/workflows/update_taxonomy.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           python-version: "3.10"
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Get changed files
         run: |
           changed_files=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA | tr '\n' ',' | sed 's/,$/\n/')


### PR DESCRIPTION
When upgrading actions/checkout from v1 to v4, the fetch-depth parameter changed to 1 (from 0 previously).
This means that only the most recent commit was fetched, preventing the proper detection of changed files.

Revert back to the old behavior by setting fetch-depth to 0 to fetch the entire repo (probably overkill, 2 might work as well).

Also delete the long-unused `hub-tests` submodule to remove some warnings in the cleanup of the checkout action.