### PR TITLE
Add target fqdn to http_base

### DIFF
--- a/contexts/crowdsecurity/http_base.yaml
+++ b/contexts/crowdsecurity/http_base.yaml
@@ -8,3 +8,5 @@ context:
   - evt.Meta.http_verb
   status:
     - evt.Meta.http_status
+  target_fdqn:
+    - evt.Meta.target_fqdn


### PR DESCRIPTION
If your a user that runs alot of subdomains, you might want to know what subdomain the event happened on.