### PR TITLE
Adding QUIC.cloud CDN to the postoverflow scenarios

### DIFF
--- a/postoverflows/s01-whitelist/crowdsecurity/cdn-qc-whitelsit.md
+++ b/postoverflows/s01-whitelist/crowdsecurity/cdn-qc-whitelsit.md
@@ -1,0 +1,3 @@
+Postoverflow whitelist for QUIC CDN
+
+Since this postoveflow only relies on the overflown IP address this postoverflow can be installed without any dependencies`

--- a/postoverflows/s01-whitelist/crowdsecurity/cdn-qc-whitelsit.yaml
+++ b/postoverflows/s01-whitelist/crowdsecurity/cdn-qc-whitelsit.yaml
@@ -1,0 +1,12 @@
+name: crowdsecurity/cdn-whitelist
+description: "Whitelist CDN provider QUIC.cloud"
+whitelist:
+  reason: "CDN provider QUIC.cloud"
+  expression: 
+    - "evt.Overflow.Alert.Source.IP in File('quic_cloud_ips.txt')"
+
+data:
+  - source_url: https://www.quic.cloud/ips?ln
+    dest_file: quic_cloud_ips.txt
+    type: string
+

--- a/postoverflows/s01-whitelist/crowdsecurity/cdn-qc-whitelsit.yaml
+++ b/postoverflows/s01-whitelist/crowdsecurity/cdn-qc-whitelsit.yaml
@@ -1,4 +1,4 @@
-name: crowdsecurity/cdn-whitelist
+name: crowdsecurity/quic-cdn-whitelist
 description: "Whitelist CDN provider QUIC.cloud"
 whitelist:
   reason: "CDN provider QUIC.cloud"


### PR DESCRIPTION
Adding QUIC.cloud, Litespeeds main own CDN, as a new post-overflow scenario for CDN whitelists. 