### PR TITLE
Add ssh auth failure message variant for preauth without user

### DIFF
--- a/.tests/sshd-logs/parser.assert
+++ b/.tests/sshd-logs/parser.assert
@@ -1,5 +1,5 @@
 len(results) == 3
-len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 16
+len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 18
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Success == true
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["program"] == "sshd"
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["timestamp"] == "Feb 12 14:10:21"
@@ -144,7 +144,26 @@ results["s00-raw"]["crowdsecurity/syslog-logs"][15].Evt.Parsed["message"] == "Co
 results["s00-raw"]["crowdsecurity/syslog-logs"][15].Evt.Meta["datasource_path"] == "sshd-logs.log"
 results["s00-raw"]["crowdsecurity/syslog-logs"][15].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/syslog-logs"][15].Evt.Meta["machine"] == "hostname"
-len(results["s01-parse"]["crowdsecurity/sshd-logs"]) == 16
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Success == true
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Parsed["pid"] == "277078"
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Parsed["program"] == "sshd"
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Parsed["timestamp"] == "Apr 05 16:29:20"
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Parsed["logsource"] == "syslog"
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Parsed["message"] == "Connection closed by 87.236.176.236 port 52909"
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Meta["datasource_path"] == "sshd-logs.log"
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Meta["datasource_type"] == "file"
+results["s00-raw"]["crowdsecurity/syslog-logs"][16].Evt.Meta["machine"] == "hostname"
+
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Success == true
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Parsed["pid"] == "277079"
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Parsed["program"] == "sshd"
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Parsed["timestamp"] == "Apr 05 16:29:20"
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Parsed["logsource"] == "syslog"
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Parsed["message"] == "Connection closed by 87.236.176.236 port 44845 [preauth]"
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Meta["datasource_path"] == "sshd-logs.log"
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Meta["datasource_type"] == "file"
+results["s00-raw"]["crowdsecurity/syslog-logs"][17].Evt.Meta["machine"] == "hostname"
+len(results["s01-parse"]["crowdsecurity/sshd-logs"]) == 18
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Success == true
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Evt.Parsed["pid"] == "16378"
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Evt.Parsed["sshd_invalid_user"] == "pascal"
@@ -365,4 +384,31 @@ results["s01-parse"]["crowdsecurity/sshd-logs"][15].Evt.Meta["machine"] == "host
 results["s01-parse"]["crowdsecurity/sshd-logs"][15].Evt.Meta["service"] == "ssh"
 results["s01-parse"]["crowdsecurity/sshd-logs"][15].Evt.Meta["source_ip"] == "80.94.92.63"
 results["s01-parse"]["crowdsecurity/sshd-logs"][15].Evt.Meta["target_user"] == "root"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Success == true
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Parsed["logsource"] == "syslog"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Parsed["pid"] == "277078"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Parsed["sshd_client_ip"] == "87.236.176.236"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Parsed["message"] == "Connection closed by 87.236.176.236 port 52909"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Parsed["program"] == "sshd"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Parsed["timestamp"] == "Apr 05 16:29:20"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Meta["datasource_path"] == "sshd-logs.log"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Meta["log_type"] == "ssh_failed-auth"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Meta["machine"] == "hostname"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Meta["service"] == "ssh"
+results["s01-parse"]["crowdsecurity/sshd-logs"][16].Evt.Meta["source_ip"] == "87.236.176.236"
+
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Success == true
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Parsed["logsource"] == "syslog"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Parsed["pid"] == "277079"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Parsed["sshd_client_ip"] == "87.236.176.236"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Parsed["message"] == "Connection closed by 87.236.176.236 port 44845 [preauth]"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Parsed["program"] == "sshd"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Parsed["timestamp"] == "Apr 05 16:29:20"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Meta["datasource_path"] == "sshd-logs.log"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Meta["log_type"] == "ssh_failed-auth"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Meta["machine"] == "hostname"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Meta["service"] == "ssh"
+results["s01-parse"]["crowdsecurity/sshd-logs"][17].Evt.Meta["source_ip"] == "87.236.176.236"
 len(results["success"][""]) == 0

--- a/.tests/sshd-logs/sshd-logs.log
+++ b/.tests/sshd-logs/sshd-logs.log
@@ -14,3 +14,5 @@ Jun  8 10:44:36 server sshd[3204729]: Unable to negotiate with 123.57.135.134 po
 Jun  7 04:07:10 server sshd[1941162]: Unable to negotiate with 206.189.59.169 port 34386: no matching host key type found. Their offer: ssh-rsa,ssh-dss [preauth]
 Jul  7 06:11:48 node1 sshd[1625360]: Unable to negotiate with 123.123.123.123 port 45296: no matching MAC found. Their offer: hmac-sha2-256,hmac-sha1,hmac-sha1-96 [preauth]
 Feb 8 17:15:01 hostname sshd[1478159]: Connection reset by authenticating user root 80.94.92.63 port 49115 [preauth]
+Apr 05 16:29:20 hostname sshd[277078]: Connection closed by 87.236.176.236 port 52909
+Apr 05 16:29:20 hostname sshd[277079]: Connection closed by 87.236.176.236 port 44845 [preauth]

--- a/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
@@ -12,7 +12,7 @@ pattern_syntax:
   SSHD_MAGIC_VALUE_FAILED: 'Magic value check failed \(\d+\) on obfuscated handshake from %{IP_WORKAROUND:sshd_client_ip} port \d+'
   SSHD_INVALID_USER: 'Invalid user\s*%{USERNAME:sshd_invalid_user}? from %{IP_WORKAROUND:sshd_client_ip}( port \d+)?'
   SSHD_INVALID_BANNER: 'banner exchange: Connection from %{IP_WORKAROUND:sshd_client_ip} port \d+: invalid format'
-  SSHD_PREAUTH_AUTHENTICATING_USER: 'Connection (closed|reset) by (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
+  SSHD_PREAUTH_AUTHENTICATING_USER: 'Connection (closed|reset) by( (authenticating|invalid) user %{USERNAME:sshd_invalid_user})? %{IP_WORKAROUND:sshd_client_ip} port \d+( \[preauth\])?'
   #following: https://github.com/crowdsecurity/crowdsec/issues/1201 - some scanners behave differently and trigger this one
   SSHD_PREAUTH_AUTHENTICATING_USER_ALT: 'Disconnected from (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
   SSHD_BAD_KEY_NEGOTIATION: 'Unable to negotiate with %{IP_WORKAROUND:sshd_client_ip} port \d+: no matching (host key type|key exchange method|MAC) found.'


### PR DESCRIPTION
ssh preauth may or may not have user part & also the `[perauth]` part

PS. i was not able to run the tests the documentation [here ](https://doc.crowdsec.net/docs/contributing/contributing_test_env/) seems to not work 

feel free to edit this PR or point me in the right direction to test my changes :) 