### PR TITLE
Update Mikrotik collection

### DIFF
--- a/collections/a1ad/mikrotik.md
+++ b/collections/a1ad/mikrotik.md
@@ -5,7 +5,6 @@ A collection to defend [Mikrotik](https://mikrotik.com/) firewall against portsc
 - Mikrotik portscan scenario
 - Mikrotik brute force scenario
 
-You need to set up a remote syslog server. There is no crowdsec client on the Mikrotik, so log parsing needs to be done on the rsyslog server.
 Do not forget to set "Firewall" flag in the remote log settings and create a drop rule with logging active.
 For brute force detection you need to set the "error" flag.
 
@@ -15,10 +14,25 @@ As bouncer you can use the [cs-mikrotik-bouncer](https://hub.crowdsec.net/author
 
 Example acquisition for this collection :
 
+Option number 1:
+Setup local Syslog server to feed the Syslog to the crowdsec parser
+
 ```yaml
 ---
 filenames:
  - /var/log/rsyslog/10.10.10.1/syslog.log
 labels:
   type: mikrotik
+```
+
+Option number 2:
+Using built-in [Crowdsec&ensp;SyslogServer](https://docs.crowdsec.net/docs/data_sources/syslog) to receive events, for style compatibility, enable BSD syslog style in crowdsec log action in your RouterOS.
+
+```yaml
+---
+source: syslog
+listen_addr: #IP_ADDRESS_of_Crowdsec
+listen_port: #Portnumber_you_want_syslog_listen_on_it
+labels:
+ type: mikrotik
 ```

--- a/parsers/s01-parse/a1ad/mikrotik-logs.md
+++ b/parsers/s01-parse/a1ad/mikrotik-logs.md
@@ -1,8 +1,12 @@
 Parser for [Mikrotik](https://mikrotik.com/) Logs.
 
-You need to set up a remote syslog server. There is no crowdsec client on the Mikrotik, so log parsing needs to be done on the rsyslog server.
 Do not forget to set "Firewall" flag in the remote log settings and create a drop rule with logging active.
 For user authentication you need to set the "error" flag.
+
+## Acquisition template
+
+Option number 1:
+Setup local Syslog server to feed the Syslog to the crowdsec parser
 
 ```yaml
 ---
@@ -10,4 +14,16 @@ filenames:
  - /var/log/rsyslog/10.10.10.1/syslog.log
 labels:
   type: mikrotik
+```
+
+Option number 2:
+Using built-in [Crowdsec&ensp;SyslogServer](https://docs.crowdsec.net/docs/data_sources/syslog) to receive events, for style compatibility, enable BSD syslog style in crowdsec log action in your RouterOS.
+
+```yaml
+---
+source: syslog
+listen_addr: #IP_ADDRESS_of_Crowdsec
+listen_port: #Portnumber_you_want_syslog_listen_on_it
+labels:
+ type: mikrotik
 ```

--- a/parsers/s01-parse/a1ad/mikrotik-logs.yaml
+++ b/parsers/s01-parse/a1ad/mikrotik-logs.yaml
@@ -4,8 +4,8 @@ filter: "evt.Parsed.program == 'mikrotik'"
 name: a1ad/mikrotik-logs
 description: "Parse Mikrotik logs"
 pattern_syntax:
-  MIKROTIK_FIREWALL_DROP: "%{TIMESTAMP_ISO8601:timestamp} %{HOSTNAME} .* %{DATA:tag} input: in:%{DATA:if_in} out:%{DATA:if_out}, connection-state:%{DATA:connection_state} src-mac %{MAC:src_mac}, proto %{WORD:proto}.*, %{IP:source_ip}:%{INT:src_port}->%{IP:dst_ip}:%{INT:dst_port}, len %{INT:length}"
-  MIKROTIK_AUTH_FAILED: "%{TIMESTAMP_ISO8601:timestamp} %{HOSTNAME} .* login failure for user %{USERNAME:invalid_user} from %{IP:source_ip}"
+  MIKROTIK_FIREWALL_DROP: "(%{SYSLOGTIMESTAMP:timestamp}|%{TIMESTAMP_ISO8601:timestamp}) %{HOSTNAME:device_name} %{DATA:action}: in:%{DATA:if_in} out:%{DATA:if_out}(, packet-mark:%{DATA:packet_mark})?(, connection-mark:%{DATA:connection_mark})? connection-state:%{DATA:connection_state}( src-mac %{MAC:src_mac})?(, )?proto %{WORD:proto}( \\(%{DATA:proto_detail}(, type %{INT:icmp_type}, code %{INT:icmp_code})?)\\)?, %{IP:source_ip}:%{INT:src_port}->%{IP:dst_ip}:%{INT:dst_port}(, len %{INT:length})?"
+  MIKROTIK_AUTH_FAILED: "(%{SYSLOGTIMESTAMP:timestamp}|%{TIMESTAMP_ISO8601:timestamp}) %{HOSTNAME} (AUTH_FAILED: )?login: failure for user %{USERNAME:invalid_user} from (%{MAC:source_mac}|%{IP:source_ip}) via %{DATA:application}"
 nodes:
   - grok:
      name: "MIKROTIK_FIREWALL_DROP"

--- a/scenarios/a1ad/mikrotik-bf.yaml
+++ b/scenarios/a1ad/mikrotik-bf.yaml
@@ -18,7 +18,7 @@ labels:
   label: "Mikrotik Bruteforce"
   remediation: true
 ---
-# meshcentral user-enum
+# Mikrotik user-enum
 type: leaky
 name: a1ad/mikrotik-bf_user-enum
 description: "Detect mikrotik user enum bruteforce"


### PR DESCRIPTION
Adding "how to set a built-in syslog server" in the documentation of this collection.
Some enhancements have been made in pattern detection for scenarios like packet or connection marking, which are used in the policy when the log is triggered. 
Patterns have also been updated to be compatible with the latest stable version of RouterOS v7.15.

Btw I have attached some examples of Mikrotik logs for testing.
[raw_log_example.txt](https://github.com/user-attachments/files/15594812/raw_log_example.txt)

