### PR TITLE
Update pterodactyl-wings-logs parser

### DIFF
--- a/.tests/pterodactyl-wings-bf/pterodactyl-wings-bf.log
+++ b/.tests/pterodactyl-wings-bf/pterodactyl-wings-bf.log
@@ -3,13 +3,13 @@ WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid usernam
 WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
 WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
 WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
+ WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
+ WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
+WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
+WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
+ WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
+ WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
 WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
 WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
 WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
-WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
-WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
-WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
-WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
-WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
-WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
-WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
+ WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator

--- a/.tests/pterodactyl-wings/parser.assert
+++ b/.tests/pterodactyl-wings/parser.assert
@@ -31,13 +31,13 @@ results["s00-raw"]["crowdsecurity/non-syslog"][4].Evt.Meta["datasource_path"] ==
 results["s00-raw"]["crowdsecurity/non-syslog"][4].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/non-syslog"][4].Evt.Whitelisted == false
 results["s00-raw"]["crowdsecurity/non-syslog"][5].Success == true
-results["s00-raw"]["crowdsecurity/non-syslog"][5].Evt.Parsed["message"] == "WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
+results["s00-raw"]["crowdsecurity/non-syslog"][5].Evt.Parsed["message"] == " WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
 results["s00-raw"]["crowdsecurity/non-syslog"][5].Evt.Parsed["program"] == "pterodactyl"
 results["s00-raw"]["crowdsecurity/non-syslog"][5].Evt.Meta["datasource_path"] == "pterodactyl-wings-bf.log"
 results["s00-raw"]["crowdsecurity/non-syslog"][5].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/non-syslog"][5].Evt.Whitelisted == false
 results["s00-raw"]["crowdsecurity/non-syslog"][6].Success == true
-results["s00-raw"]["crowdsecurity/non-syslog"][6].Evt.Parsed["message"] == "WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
+results["s00-raw"]["crowdsecurity/non-syslog"][6].Evt.Parsed["message"] == " WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
 results["s00-raw"]["crowdsecurity/non-syslog"][6].Evt.Parsed["program"] == "pterodactyl"
 results["s00-raw"]["crowdsecurity/non-syslog"][6].Evt.Meta["datasource_path"] == "pterodactyl-wings-bf.log"
 results["s00-raw"]["crowdsecurity/non-syslog"][6].Evt.Meta["datasource_type"] == "file"
@@ -55,13 +55,13 @@ results["s00-raw"]["crowdsecurity/non-syslog"][8].Evt.Meta["datasource_path"] ==
 results["s00-raw"]["crowdsecurity/non-syslog"][8].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/non-syslog"][8].Evt.Whitelisted == false
 results["s00-raw"]["crowdsecurity/non-syslog"][9].Success == true
-results["s00-raw"]["crowdsecurity/non-syslog"][9].Evt.Parsed["message"] == "WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
+results["s00-raw"]["crowdsecurity/non-syslog"][9].Evt.Parsed["message"] == " WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
 results["s00-raw"]["crowdsecurity/non-syslog"][9].Evt.Parsed["program"] == "pterodactyl"
 results["s00-raw"]["crowdsecurity/non-syslog"][9].Evt.Meta["datasource_path"] == "pterodactyl-wings-bf.log"
 results["s00-raw"]["crowdsecurity/non-syslog"][9].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/non-syslog"][9].Evt.Whitelisted == false
 results["s00-raw"]["crowdsecurity/non-syslog"][10].Success == true
-results["s00-raw"]["crowdsecurity/non-syslog"][10].Evt.Parsed["message"] == "WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8"
+results["s00-raw"]["crowdsecurity/non-syslog"][10].Evt.Parsed["message"] == " WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8"
 results["s00-raw"]["crowdsecurity/non-syslog"][10].Evt.Parsed["program"] == "pterodactyl"
 results["s00-raw"]["crowdsecurity/non-syslog"][10].Evt.Meta["datasource_path"] == "pterodactyl-wings-bf.log"
 results["s00-raw"]["crowdsecurity/non-syslog"][10].Evt.Meta["datasource_type"] == "file"
@@ -85,7 +85,7 @@ results["s00-raw"]["crowdsecurity/non-syslog"][13].Evt.Meta["datasource_path"] =
 results["s00-raw"]["crowdsecurity/non-syslog"][13].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/non-syslog"][13].Evt.Whitelisted == false
 results["s00-raw"]["crowdsecurity/non-syslog"][14].Success == true
-results["s00-raw"]["crowdsecurity/non-syslog"][14].Evt.Parsed["message"] == "WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
+results["s00-raw"]["crowdsecurity/non-syslog"][14].Evt.Parsed["message"] == " WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
 results["s00-raw"]["crowdsecurity/non-syslog"][14].Evt.Parsed["program"] == "pterodactyl"
 results["s00-raw"]["crowdsecurity/non-syslog"][14].Evt.Meta["datasource_path"] == "pterodactyl-wings-bf.log"
 results["s00-raw"]["crowdsecurity/non-syslog"][14].Evt.Meta["datasource_type"] == "file"
@@ -185,7 +185,7 @@ results["s01-parse"]["lourys/pterodactyl-wings-logs"][4].Evt.Meta["source_ip"] =
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][4].Evt.Meta["target_user"] == "test.3f22e5c8"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][4].Evt.Whitelisted == false
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Success == true
-results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Parsed["message"] == "WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
+results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Parsed["message"] == " WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Parsed["program"] == "pterodactyl"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Parsed["source_port"] == "43244"
@@ -199,7 +199,7 @@ results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Meta["source_ip"] =
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Meta["target_user"] == "administrator"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][5].Evt.Whitelisted == false
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][6].Success == true
-results["s01-parse"]["lourys/pterodactyl-wings-logs"][6].Evt.Parsed["message"] == "WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
+results["s01-parse"]["lourys/pterodactyl-wings-logs"][6].Evt.Parsed["message"] == " WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][6].Evt.Parsed["program"] == "pterodactyl"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][6].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][6].Evt.Parsed["source_port"] == "28050"
@@ -241,7 +241,7 @@ results["s01-parse"]["lourys/pterodactyl-wings-logs"][8].Evt.Meta["source_ip"] =
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][8].Evt.Meta["target_user"] == "administrator"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][8].Evt.Whitelisted == false
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Success == true
-results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Parsed["message"] == "WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
+results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Parsed["message"] == " WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Parsed["program"] == "pterodactyl"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Parsed["source_port"] == "28050"
@@ -255,7 +255,7 @@ results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Meta["source_ip"] =
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Meta["target_user"] == "admin"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][9].Evt.Whitelisted == false
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][10].Success == true
-results["s01-parse"]["lourys/pterodactyl-wings-logs"][10].Evt.Parsed["message"] == "WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8"
+results["s01-parse"]["lourys/pterodactyl-wings-logs"][10].Evt.Parsed["message"] == " WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][10].Evt.Parsed["program"] == "pterodactyl"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][10].Evt.Parsed["source_ip"] == "10.23.89.10"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][10].Evt.Parsed["source_port"] == "30122"
@@ -311,7 +311,7 @@ results["s01-parse"]["lourys/pterodactyl-wings-logs"][13].Evt.Meta["source_ip"] 
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][13].Evt.Meta["target_user"] == "test.3f22e5c8"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][13].Evt.Whitelisted == false
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][14].Success == true
-results["s01-parse"]["lourys/pterodactyl-wings-logs"][14].Evt.Parsed["message"] == "WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
+results["s01-parse"]["lourys/pterodactyl-wings-logs"][14].Evt.Parsed["message"] == " WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][14].Evt.Parsed["program"] == "pterodactyl"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][14].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s01-parse"]["lourys/pterodactyl-wings-logs"][14].Evt.Parsed["source_port"] == "43244"
@@ -420,7 +420,7 @@ results["s02-enrich"]["crowdsecurity/dateparse-enrich"][4].Evt.Meta["timestamp"]
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][4].Evt.Enriched["MarshaledTime"] == "2024-07-02T05:14:17Z"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][4].Evt.Whitelisted == false
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Success == true
-results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Parsed["message"] == "WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Parsed["message"] == " WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Parsed["program"] == "pterodactyl"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Parsed["source_port"] == "43244"
@@ -436,7 +436,7 @@ results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Meta["timestamp"]
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Enriched["MarshaledTime"] == "2024-07-02T05:33:46Z"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][5].Evt.Whitelisted == false
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][6].Success == true
-results["s02-enrich"]["crowdsecurity/dateparse-enrich"][6].Evt.Parsed["message"] == "WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][6].Evt.Parsed["message"] == " WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][6].Evt.Parsed["program"] == "pterodactyl"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][6].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][6].Evt.Parsed["source_port"] == "28050"
@@ -484,7 +484,7 @@ results["s02-enrich"]["crowdsecurity/dateparse-enrich"][8].Evt.Meta["timestamp"]
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][8].Evt.Enriched["MarshaledTime"] == "2024-07-02T05:33:46Z"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][8].Evt.Whitelisted == false
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Success == true
-results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Parsed["message"] == "WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Parsed["message"] == " WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Parsed["program"] == "pterodactyl"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Parsed["source_port"] == "28050"
@@ -500,7 +500,7 @@ results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Meta["timestamp"]
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Enriched["MarshaledTime"] == "2024-07-02T05:05:24Z"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][9].Evt.Whitelisted == false
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][10].Success == true
-results["s02-enrich"]["crowdsecurity/dateparse-enrich"][10].Evt.Parsed["message"] == "WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][10].Evt.Parsed["message"] == " WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][10].Evt.Parsed["program"] == "pterodactyl"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][10].Evt.Parsed["source_ip"] == "10.23.89.10"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][10].Evt.Parsed["source_port"] == "30122"
@@ -564,7 +564,7 @@ results["s02-enrich"]["crowdsecurity/dateparse-enrich"][13].Evt.Meta["timestamp"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][13].Evt.Enriched["MarshaledTime"] == "2024-07-02T05:14:17Z"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][13].Evt.Whitelisted == false
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][14].Success == true
-results["s02-enrich"]["crowdsecurity/dateparse-enrich"][14].Evt.Parsed["message"] == "WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][14].Evt.Parsed["message"] == " WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][14].Evt.Parsed["program"] == "pterodactyl"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][14].Evt.Parsed["source_ip"] == "10.56.3.156"
 results["s02-enrich"]["crowdsecurity/dateparse-enrich"][14].Evt.Parsed["source_port"] == "43244"

--- a/.tests/pterodactyl-wings/pterodactyl-wings-bf.log
+++ b/.tests/pterodactyl-wings/pterodactyl-wings-bf.log
@@ -3,14 +3,14 @@ WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid usernam
 WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
 WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
 WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
+ WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
+ WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
+WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
+WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
+ WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
+ WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
 WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
 WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
 WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
-WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
-WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
-WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
-WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
-WARN: [Jul  2 05:05:24.643] failed to validate user credentials (invalid format) ip=10.56.3.156:28050 subsystem=sftp username=admin
-WARN: [Jul  2 05:14:17.037] failed to validate user credentials (invalid username or password) ip=10.23.89.10:30122 subsystem=sftp username=test.3f22e5c8
-WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
+ WARN: [Jul  2 05:33:46.809] failed to validate user credentials (invalid format) ip=10.56.3.156:43244 subsystem=sftp username=administrator
 WARN: [Aug 22 08:32:21.074] failed to validate user credentials (invalid username or password) ip=10.87.200.23:52205 method=password subsystem=sftp username=rop0glbf.1f6a0e72

--- a/parsers/s01-parse/lourys/pterodactyl-wings-logs.yaml
+++ b/parsers/s01-parse/lourys/pterodactyl-wings-logs.yaml
@@ -7,13 +7,13 @@ debug: false
 onsuccess: next_stage
 nodes:
   - grok:
-      pattern: '^WARN: \[%{PTERO_TIME:time}.*?\] failed to validate user credentials \(invalid format\) ip=%{IPORHOST:source_ip}:%{NUMBER:source_port}.* username=%{USERNAME:username}$'
+      pattern: '^\s*WARN: \[%{PTERO_TIME:time}.*?\] failed to validate user credentials \(invalid format\) ip=%{IPORHOST:source_ip}:%{NUMBER:source_port}.* username=%{USERNAME:username}$'
       apply_on: message
       statics:
         - meta: log_type
           value: pterodactly_wings_invalid_format
   - grok:
-      pattern: '^WARN: \[%{PTERO_TIME:time}.*?\] failed to validate user credentials \(invalid username or password\) ip=%{IPORHOST:source_ip}:%{NUMBER:source_port}.* username=%{USERNAME:username}$'
+      pattern: '^\s*WARN: \[%{PTERO_TIME:time}.*?\] failed to validate user credentials \(invalid username or password\) ip=%{IPORHOST:source_ip}:%{NUMBER:source_port}.* username=%{USERNAME:username}$'
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
My pterodactyl wings logs have a space character in front of WARN, add support for whitespace to appear before WARN and it can still properly parse the logfile.