### PR TITLE
Update sshd-logs.yaml with new pattern

### DIFF
--- a/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
@@ -15,6 +15,7 @@ pattern_syntax:
   SSHD_PREAUTH_AUTHENTICATING_USER: 'Connection (closed|reset) by (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
   #following: https://github.com/crowdsecurity/crowdsec/issues/1201 - some scanners behave differently and trigger this one
   SSHD_PREAUTH_AUTHENTICATING_USER_ALT: 'Disconnected from (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
+  SSHD_PREAUTH_AUTHENTICATING_IP: 'Connection (closed|reset) by %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
   SSHD_BAD_KEY_NEGOTIATION: 'Unable to negotiate with %{IP_WORKAROUND:sshd_client_ip} port \d+: no matching (host key type|key exchange method|MAC) found.'
   # in case they are blocked by /etc/ssh/sshd_config AllowUsers xx yy
   SSHD_NOT_ALLOWED_USER: 'User %{USERNAME:sshd_invalid_user}? from %{IP_WORKAROUND:sshd_client_ip}( port \d+)? not allowed because not listed in AllowUsers'
@@ -39,6 +40,14 @@ nodes:
           expression: "evt.Parsed.sshd_invalid_user"
   - grok:
       name: "SSHD_PREAUTH_AUTHENTICATING_USER"
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: ssh_failed-auth
+        - meta: target_user
+          expression: "evt.Parsed.sshd_invalid_user"
+  - grok:
+      name: "SSHD_PREAUTH_AUTHENTICATING_IP"
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
Hi, I'm using CentOS Stream 9 (not sure if this is related) my sshd service logs look like this (my server name and ip was edited):
`Aug 31 12:17:49 myserver sshd[319482]: Connection closed by xx.xx.xx.xx port 42056 [preauth]`

When using `cscli explain` (my server name and ip edited):
```
[root@myserver log]# cscli explain --log "Aug 31 12:17:49 myserver sshd[319482]: Connection closed by xx.xx.xx.xx port 42056 [preauth]" --type syslog
line: Aug 31 12:17:49 myserver sshd[319482]: Connection closed by xx.xx.xx.xx port 42056 [preauth]
	├ s00-raw
	|	└ 🟢 crowdsecurity/syslog-logs (+12 ~9)
	├ s01-parse
	|	├ 🔴 crowdsecurity/nginx-logs
	|	├ 🔴 crowdsecurity/sshd-logs
	|	└ 🔴 crowdsecurity/sshd-success-logs
	└-------- parser failure 🔴
```
Because this type of logs is unknown by CrowdSec my server is spammed with these kinds of messages. IP edited is the same.
```
[root@myserver crowdsecurity]# journalctl | grep 'Connection closed by' | tail -n 5
Aug 31 12:24:11 myserver sshd[319636]: Connection closed by xx.xx.xx.xx port 56250 [preauth]
Aug 31 12:35:35 myserver sshd[319750]: Connection closed by xx.xx.xx.xx port 52014 [preauth]
Aug 31 12:35:36 myserver sshd[319752]: Connection closed by xx.xx.xx.xx port 52026 [preauth]
Aug 31 12:43:46 myserver sshd[319796]: Connection closed by xx.xx.xx.xx port 36044 [preauth]
Aug 31 12:43:46 myserver sshd[319798]: Connection closed by xx.xx.xx.xx port 36060 [preauth]
```
My proposed new simple pattern should deal with these kinds of logs. After manually applied to to `/etc/crowdsec/hub/parsers/s01-parse/crowdsecurity/sshd-logs.yaml`, this is the result:
```
[root@myserver crowdsecurity]# cscli explain --log "Aug 31 12:17:49 myserver sshd[319482]: Connection closed by xx.xx.xx.xx port 42056 [preauth]" --type syslog
line: Aug 31 12:17:49 myserver sshd[319482]: Connection closed by xx.xx.xx.xx port 42056 [preauth]
	├ s00-raw
	|	└ 🟢 crowdsecurity/syslog-logs (+12 ~9)
	├ s01-parse
	|	├ 🔴 crowdsecurity/nginx-logs
	|	└ 🟢 crowdsecurity/sshd-logs (+4 ~1)
	├ s02-enrich
	|	├ 🟢 crowdsecurity/dateparse-enrich (+2 ~2)
	|	├ 🟢 crowdsecurity/geoip-enrich (+13)
	|	├ 🔴 crowdsecurity/http-logs
	|	└ 🟢 crowdsecurity/whitelists (unchanged)
	├-------- parser success 🟢
	├ Scenarios
		├ 🟢 crowdsecurity/ssh-bf
		├ 🟢 crowdsecurity/ssh-bf_user-enum
		├ 🟢 crowdsecurity/ssh-slow-bf
		└ 🟢 crowdsecurity/ssh-slow-bf_user-enum
```

I hope this proposed change will be considered helpful, I'm not very experienced with CrowdSec yet. Thanks for creating it! :)