### PR TITLE
Update geoip-enrich.yaml to include default k3s ip range

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/geoip-enrich.yaml
+++ b/parsers/s02-enrich/crowdsecurity/geoip-enrich.yaml
@@ -3,7 +3,7 @@ filter: |
   "source_ip" in evt.Meta &&
   (
     not ipv6Check &&
-    not (IpInRange(evt.Meta.source_ip, "127.0.0.0/8") || IpInRange(evt.Meta.source_ip, "192.168.0.0/16") || IpInRange(evt.Meta.source_ip, "172.16.0.0/12") || IpInRange(evt.Meta.source_ip, "10.0.0.0/8"))
+    not (IpInRange(evt.Meta.source_ip, "127.0.0.0/8") || IpInRange(evt.Meta.source_ip, "192.168.0.0/16") || IpInRange(evt.Meta.source_ip, "172.16.0.0/12") || IpInRange(evt.Meta.source_ip, "10.0.0.0/8") || IpInRange(evt.Meta.source_ip, "10.42.0.0/16") || IpInRange(evt.Meta.source_ip, "10.43.0.0/16"))
   ) ||
   (
     ipv6Check &&


### PR DESCRIPTION
k3s flannel CIDR has the following ranges by default: https://docs.k3s.io/cli/server#networking

This will prevent spammy logs for k3s clusters