### PR TITLE
Update plex-allowlist.yaml

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
+++ b/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
@@ -4,10 +4,11 @@ filter: "evt.Meta.service == 'http' && evt.Meta.log_type in ['http_access-log', 
 whitelist:
   reason: "Plex Allowlist"
   expression:
-   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/video/:/transcode/'
+   - evt.Meta.http_status in ['200', '404'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/video/:/transcode/'
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/photo/:/transcode/'
    - evt.Meta.http_status in ['200', '400'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/:/timeline'
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path matches '^/library/metadata/\\d+'
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path == '/status/sessions'
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/playQueues/'
    - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'POST' && evt.Parsed.request == '/log' && evt.Parsed.http_args contains 'X-Plex-Product=Plex%20Cast&X-Plex-Version='
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/music/:/transcode/universal/session/'

--- a/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
+++ b/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
@@ -6,6 +6,8 @@ whitelist:
   expression:
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/video/:/transcode/'
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/photo/:/transcode/'
-   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/:/timeline'
+   - evt.Meta.http_status in ['200', '400'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/:/timeline'
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path matches '^/library/metadata/\\d+'
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path == '/status/sessions'
+   - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/playQueues/'
+   - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'POST' && evt.Parsed.request == '/log' && evt.Parsed.http_args contains 'X-Plex-Product=Plex%20Cast&X-Plex-Version='


### PR DESCRIPTION
Casting from a browser or Android Plex app or iOS Plex app to Plex app on a local AndroidTV device triggers alerts and decisions from LePresidente/http-generic-403-bf and crowdsecurity/http-probing. With these changes I can no longer trigger alerts when I've tested with casting.