### PR TITLE
remove cloudfront invalidation

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -54,21 +54,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
-
-  check-secret:
-    runs-on: ubuntu-latest
-    outputs:
-      secret-exists: ${{ steps.check.outputs.exists }}
-    steps:
-      - name: Check for Secret availability
-        id: check
-        shell: bash
-        run: |
-          if [ "${{ secrets.CF_DISTRIBUTION_ID }}" != '' ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT;
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT;
-          fi
   
   run-linter:
     runs-on: ubuntu-latest
@@ -94,48 +79,3 @@ jobs:
         run: |
           pipenv run ./hublint defaults > .hublint.toml
           pipenv run ./hublint check --color always --no-warning-details
-
-
-  invalidate-cache:
-    runs-on: ubuntu-latest
-    needs: 
-      - build
-      - check-secret
-      - run-linter
-    if: needs.check-secret.outputs.secret-exists == 'true'
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.CF_AWS_ROLE }}
-          role-session-name: github-action
-          aws-region: eu-west-1
-          mask-aws-account-id: true
-      - name: Get branch name
-        run: echo "version=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: Get changed files
-        run: |
-          changed_files=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA | tr '\n' ',' | sed 's/,$/\n/')
-          echo "changed_files=${changed_files}" >> $GITHUB_ENV
-      - name: Invalidate cache
-        run: |
-          create_invalidation() {
-            #$1 is not quotted on purpose, so it can be expanded to multiple arguments
-            aws cloudfront create-invalidation --distribution-id ${{ secrets.CF_DISTRIBUTION_ID }} --paths $1
-          }
-          PATHS="/${{ env.version }}/.index.json"
-          IFS=',' read -ra FILE <<< "${{ env.changed_files }}"
-          for i in "${FILE[@]}"; do
-            PATHS="$PATHS /${{ env.version }}/$i"
-          done
-          echo "Invalidating paths: $PATHS"
-          for ((i=0; i < 3; i++)); do
-            create_invalidation "$PATHS" && break || echo "Invalidation failed, retrying in 5 seconds..."
-            sleep 5
-          done


### PR DESCRIPTION
As crowdsec and the console both now use HAPI to get the hub content, the index file that was served directly from github through cloudfront is not accessed directly anymore, so we can remove the cache invalidation: this also removes a secret, which should allow the index update job to run properly on forks.

If we need to update the hub for an older version of crowdsec (which rarely happens), we'll need to manually run the cache invalidation.