### PR TITLE
Enhance: appsec sceanario split and collection updates

### DIFF
--- a/collections/crowdsecurity/appsec-generic-rules.yaml
+++ b/collections/crowdsecurity/appsec-generic-rules.yaml
@@ -10,6 +10,7 @@ parsers:
   - crowdsecurity/appsec-logs
 scenarios:
   - crowdsecurity/appsec-vpatch
+  - crowdsecurity/appsec-native
 contexts:
   - crowdsecurity/appsec_base
 description: "A collection of generic attack vectors for additional protection."

--- a/collections/crowdsecurity/appsec-virtual-patching.yaml
+++ b/collections/crowdsecurity/appsec-virtual-patching.yaml
@@ -90,3 +90,4 @@ parsers:
 - crowdsecurity/appsec-logs
 scenarios:
 - crowdsecurity/appsec-vpatch
+- crowdsecurity/appsec-native

--- a/collections/crowdsecurity/appsec-wordpress.yaml
+++ b/collections/crowdsecurity/appsec-wordpress.yaml
@@ -16,5 +16,12 @@ appsec-rules:
   - crowdsecurity/vpatch-CVE-2024-6205
 appsec-configs:
   - crowdsecurity/virtual-patching
+parsers:
+  - crowdsecurity/appsec-logs
+scenarios:
+  - crowdsecurity/appsec-vpatch
+  - crowdsecurity/appsec-native
+contexts:
+  - crowdsecurity/appsec_base
 description: "A virtual patching collection, suitable for WordPress websites"
 author: crowdsecurity

--- a/scenarios/crowdsecurity/appsec-native.yaml
+++ b/scenarios/crowdsecurity/appsec-native.yaml
@@ -1,8 +1,8 @@
 type: leaky
 format: 3.0
-name: crowdsecurity/appsec-vpatch
-description: "Identify attacks flagged by CrowdSec AppSec"
-filter: "evt.Meta.log_type == 'appsec-block' && evt.Meta.rule_name not startsWith 'native_rule'"
+name: crowdsecurity/appsec-native
+description: "Identify attacks flagged by CrowdSec AppSec via native rules"
+filter: "evt.Meta.log_type == 'appsec-block' && evt.Meta.rule_name startsWith 'native_rule'"
 distinct: evt.Meta.rule_name
 leakspeed: "60s"
 capacity: 1
@@ -10,7 +10,7 @@ groupby: evt.Meta.source_ip
 blackhole: 1m
 labels:
   service: http
-  confidence: 3
+  confidence: 1
   spoofable: 0
   classification:
     - attack.T1110

--- a/scenarios/crowdsecurity/appsec-vpatch.yaml
+++ b/scenarios/crowdsecurity/appsec-vpatch.yaml
@@ -2,6 +2,7 @@ type: leaky
 format: 3.0
 name: crowdsecurity/appsec-vpatch
 description: "Identify attacks flagged by CrowdSec AppSec"
+## See appsec-native.yaml for reasons why we created a negative startsWith here, we want to ignore is native_rules but catch any of our DSL rules.
 filter: "evt.Meta.log_type == 'appsec-block' && evt.Meta.rule_name not startsWith 'native_rule'"
 distinct: evt.Meta.rule_name
 leakspeed: "60s"


### PR DESCRIPTION
The change aims at the following:
 - add a scenario for native rules with a lower confidence score
 - ensure the vpatch scenario doesn't pick up on native rules, but will pick up any other rules (both vpatch and user-defined)

In the future we might want to find a better way to separate user-defined rules and crowdsec's provided vpatch rules.
