### PR TITLE
detect wordpress scanning of txt and md files

### DIFF
--- a/.tests/http-wordpress-scan/http-wordpress-scan.log
+++ b/.tests/http-wordpress-scan/http-wordpress-scan.log
@@ -3,3 +3,5 @@
 127.0.0.1 - - [19/Apr/2024:14:41:25 +0200] "GET /activate/wp-content/plugins/advanced-dewplayer/admin-panel/download-file.php HTTP/1.1" 404 153 "-" "curl/7.68.0"
 127.0.0.1 - - [19/Apr/2024:14:41:26 +0200] "GET /wp-content/plugins/sniplets/modules/syntax_highlight.php HTTP/1.1" 404 153 "-" "curl/7.68.0"
 127.0.0.1 - - [19/Apr/2024:14:41:26 +0200] "GET /wp-content/plugins/sniplets/view/sniplets/warning.php HTTP/1.1" 404 153 "-" "curl/7.68.0"
+127.0.0.1 - - [01/Mar/2025:18:09:52 +1100] "HEAD /wp-content/plugins/blocksy-companion/README.txt HTTP/2.0" 404 0 "https://example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1092.0 Safari/536.6"
+127.0.0.1 - - [01/Mar/2025:18:09:53 +1100] "HEAD /wp-content/plugins/blocksy-companion/README.md HTTP/2.0" 404 0 "https://example.com" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1092.0 Safari/536.6"

--- a/scenarios/crowdsecurity/http-wordpress-scan.yaml
+++ b/scenarios/crowdsecurity/http-wordpress-scan.yaml
@@ -2,11 +2,11 @@ type: leaky
 name: crowdsecurity/http-wordpress-scan
 description: "Detect WordPress scan: vuln hunting"
 filter: |
-  evt.Meta.service == 'http' and 
-  evt.Meta.log_type in ['http_access-log', 'http_error-log'] and 
+  evt.Meta.service == 'http' and
+  evt.Meta.log_type in ['http_access-log', 'http_error-log'] and
   evt.Meta.http_status in ['404', '403'] and
   Lower(evt.Meta.http_path) contains "/wp-" and
-  Lower(evt.Meta.http_path) endsWith ".php"
+  Lower(evt.Meta.http_path) matches "\\.(php|txt|md)$"
 groupby: evt.Meta.source_ip
 distinct: evt.Meta.http_path
 capacity: 3


### PR DESCRIPTION
Bots don't only scan the php files, they also scan for txt and md files and sometimes will only scan for one file type to try and evade detection.