### PR TITLE
Whitelist whole ipv4 loopback cidr instead of just 127.0.0.1

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/whitelists.md
+++ b/parsers/s02-enrich/crowdsecurity/whitelists.md
@@ -1,10 +1,10 @@
 A generic whitelist to avoid banning yourself.
 
 ### whitelisted ips:
- - 127.0.0.1
  - ::1
 
 ### whitelisted ranges:
+ - 127.0.0.0/8
  - 192.168.0.0/16
  - 10.0.0.0/8
  - 172.16.0.0/12

--- a/parsers/s02-enrich/crowdsecurity/whitelists.yaml
+++ b/parsers/s02-enrich/crowdsecurity/whitelists.yaml
@@ -3,9 +3,9 @@ description: "Whitelist events from private ipv4 addresses"
 whitelist:
   reason: "private ipv4/ipv6 ip/ranges"
   ip: 
-    - "127.0.0.1"
     - "::1"
   cidr:
+    - "127.0.0.0/8"
     - "192.168.0.0/16"
     - "10.0.0.0/8"
     - "172.16.0.0/12"


### PR DESCRIPTION
### Description

This PR expands the whitelist from just 127.0.0.1 to the entire 127.0.0.0/8 loopback range as defined in [RFC5735](https://www.rfc-editor.org/rfc/rfc5735) and [RFC1122 Section 3.2.1.3](https://www.rfc-editor.org/rfc/rfc1122#section-3.2.1.3). According to these RFCs, all addresses in this range are reserved for loopback and should never appear on any network, making them safe to whitelist.

For IPv6, the whitelist correctly includes only ::1/128 as specified in [RFC5156](https://www.rfc-editor.org/rfc/rfc5156).



### Motivation

I just bug-hunted for several days, `127.0.0.53` was being banned, which caused DNS(systemd-resolved) to break, which caused my auto-install script for crowdsec parsers/collections to fail, which caused this whitelist to not be installed, which then caused bans on `127.0.0.1`, which made crowdsec completely undebuggable. Finally found out the cause when moving crowdsec to ipv6. :crying_cat_face: 



I can see why you'd want to keep the default whitelist as is, so feel free to reject the PR, just thought it might save someone else a few hours of annoying debugging...