### PR TITLE
Filebrowser Collection allow parsing IPv6

### DIFF
--- a/collections/MrShippeR/filebrowser.md
+++ b/collections/MrShippeR/filebrowser.md
@@ -16,6 +16,7 @@ It includes:
 
 ## Alert log example
 2025/04/10 12:34:56 /api/login: 403 192.168.1.100 <nil>
+2025/05/27 12:18:16 /api/login: 403 2405:8100:8000:5ca1::229:8abd <nil>
 
 ## Installation
 You can install this collection with:

--- a/collections/MrShippeR/filebrowser.md
+++ b/collections/MrShippeR/filebrowser.md
@@ -15,7 +15,8 @@ It includes:
 | Scenario | `MrShippeR/filebrowser_bf`     | Detect brute-force login attempts detection       |
 
 ## Alert log example
-2025/04/10 12:34:56 /api/login: 403 192.168.1.100 <nil>
+
+2025/04/10 12:34:56 /api/login: 403 192.168.1.100 <nil>  
 2025/05/27 12:18:16 /api/login: 403 2405:8100:8000:5ca1::229:8abd <nil>
 
 ## Installation

--- a/collections/MrShippeR/filebrowser.yaml
+++ b/collections/MrShippeR/filebrowser.yaml
@@ -1,5 +1,6 @@
 name: MrShippeR/filebrowser
 description: "FileBrowser support : parser and scenario for bruteforce detection"
+version: 0.2.0
 author: MrShippeR
 tags:
   - linux

--- a/collections/MrShippeR/filebrowser.yaml
+++ b/collections/MrShippeR/filebrowser.yaml
@@ -1,6 +1,5 @@
 name: MrShippeR/filebrowser
 description: "FileBrowser support : parser and scenario for bruteforce detection"
-version: 0.2.0
 author: MrShippeR
 tags:
   - linux

--- a/parsers/s01-parse/MrShippeR/filebrowser-logs.md
+++ b/parsers/s01-parse/MrShippeR/filebrowser-logs.md
@@ -3,7 +3,7 @@ Parser for [FileBrowser vanilla app](https://filebrowser.org/) logs.
 ```yaml
 ---
 filenames:
-  - /home/shipper/docker/filebrowser/config/filebrowser.log  # Nahraď správnou cestou
+  - /home/shipper/docker/filebrowser/config/filebrowser.log 
 labels:
   type: filebrowser
 ```

--- a/parsers/s01-parse/MrShippeR/filebrowser-logs.yaml
+++ b/parsers/s01-parse/MrShippeR/filebrowser-logs.yaml
@@ -4,7 +4,7 @@ onsuccess: next_stage
 filter: "evt.Parsed.program == 'filebrowser'"
 
 pattern_syntax:
-  FILEBROWSER_FAILED_AUTH: "%{NGINXERRTIME:event_timestamp} /api/login: 403 %{IPV4:source_ip} <nil>"
+  FILEBROWSER_FAILED_AUTH: "%{NGINXERRTIME:event_timestamp} /api/login: 403 %{IP:source_ip} <nil>"
 
 nodes:
   - grok:


### PR DESCRIPTION
Hello,
I'm author of Filebrowser collection. Comming with update.

Main point of this update is to fix **pattern_syntax** of parser. Changing `%{IPV4:source_ip}` to `%{IP:source_ip}`. So it will process both IPv4 and IPv6 adresess.  



_Giving credit to ollieblazejames@gmail.com for idea and realization._