### PR TITLE
Update generic-wordpress-uploads-listing.yaml

### DIFF
--- a/appsec-rules/crowdsecurity/generic-wordpress-uploads-listing.yaml
+++ b/appsec-rules/crowdsecurity/generic-wordpress-uploads-listing.yaml
@@ -9,7 +9,7 @@ rules:
       - urldecode
       match:
         type: regex
-        value: '/wp-content/uploads/$'
+        value: '^/wp-content/uploads/$'
     - zones: 
       - URI
       transform:
@@ -17,7 +17,7 @@ rules:
       - urldecode
       match:
         type: regex
-        value: '/wp-content/uploads/.*/$'
+        value: '^/wp-content/uploads/.*/$'
     
 labels:
    type: exploit


### PR DESCRIPTION
We noticed some potential false positives with `wp-cache` mechanisms, we reached out to user to see if these are legit, until we have confirmation we simply limit the WAF rules to starts with and ignore to `wp-cache` directory.

the only downside if wordpress is served from a directory EG: `/blog/wp-content/uploads` then this rule no longer works but we rather limit the potential blow back for now.