### PR TITLE
enhance: Appsec no user agent typical of bot or raw http attack

### DIFF
--- a/.appsec-tests/generic-no-user-agent/config.yaml
+++ b/.appsec-tests/generic-no-user-agent/config.yaml
@@ -1,0 +1,3 @@
+appsec-rules:
+- ./appsec-rules/crowdsecurity/generic-no-user-agent.yaml
+nuclei_template: generic-no-user-agent.yaml

--- a/.appsec-tests/generic-no-user-agent/config.yaml
+++ b/.appsec-tests/generic-no-user-agent/config.yaml
@@ -1,3 +1,3 @@
 appsec-rules:
-- ./appsec-rules/crowdsecurity/generic-no-user-agent.yaml
+- ./appsec-rules/crowdsecurity/experimental-no-user-agent.yaml
 nuclei_template: generic-no-user-agent.yaml

--- a/.appsec-tests/generic-no-user-agent/generic-no-user-agent.yaml
+++ b/.appsec-tests/generic-no-user-agent/generic-no-user-agent.yaml
@@ -1,0 +1,49 @@
+id: generic-no-user-agent
+info:
+  name: generic-no-user-agent
+  author: crowdsec
+  severity: info
+  description: generic-no-user-agent testing
+  tags: appsec-testing
+http:
+  - raw:
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent:
+      - |
+        POST / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent:
+      - |
+        PUT / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent:
+      - |
+        DELETE / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent:
+      - |
+        PATCH / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: 
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
+      - |
+        HEAD / HTTP/1.1
+        Host: {{Hostname}}
+        User-Agent:
+    matchers:
+      - type: dsl
+        condition: and
+        dsl:
+          - "status_code_1 == 403"
+          - "status_code_2 == 403"
+          - "status_code_3 == 403"
+          - "status_code_4 == 403"
+          - "status_code_5 == 403"
+          - "status_code_6 == 200"
+          - "status_code_7 == 200"
+

--- a/.appsec-tests/generic-no-user-agent/generic-no-user-agent.yaml
+++ b/.appsec-tests/generic-no-user-agent/generic-no-user-agent.yaml
@@ -1,9 +1,9 @@
-id: generic-no-user-agent
+id: experimental-no-user-agent
 info:
-  name: generic-no-user-agent
+  name: experimental-no-user-agent
   author: crowdsec
   severity: info
-  description: generic-no-user-agent testing
+  description: experimental-no-user-agent testing
   tags: appsec-testing
 http:
   - raw:

--- a/appsec-configs/crowdsecurity/appsec-default.yaml
+++ b/appsec-configs/crowdsecurity/appsec-default.yaml
@@ -5,4 +5,5 @@ inband_rules:
  - crowdsecurity/vpatch-*
  - crowdsecurity/generic-*
 outofband_rules:
+ - crowdsecurity/experimental-*
  - crowdsecurity/appsec-generic-test

--- a/appsec-configs/crowdsecurity/generic-rules.yaml
+++ b/appsec-configs/crowdsecurity/generic-rules.yaml
@@ -3,3 +3,5 @@ default_remediation: ban
 inband_rules:
  - crowdsecurity/base-config 
  - crowdsecurity/generic-*
+outofband_rules:
+ - crowdsecurity/experimental-*

--- a/appsec-rules/crowdsecurity/experimental-no-user-agent.yaml
+++ b/appsec-rules/crowdsecurity/experimental-no-user-agent.yaml
@@ -1,4 +1,4 @@
-name: crowdsecurity/generic-no-user-agent
+name: crowdsecurity/experimental-no-user-agent
 description: "Protect against no user agent"
 rules:
 ## Useragent header does not exist

--- a/appsec-rules/crowdsecurity/experimental-no-user-agent.yaml
+++ b/appsec-rules/crowdsecurity/experimental-no-user-agent.yaml
@@ -24,7 +24,7 @@ rules:
 labels:
    type: exploit
    service: http
-   confidence: 2
+   confidence: 0
    spoofable: 0
    behavior: "http:exploit"
    label: "Protect against no user agent"

--- a/appsec-rules/crowdsecurity/generic-no-user-agent.yaml
+++ b/appsec-rules/crowdsecurity/generic-no-user-agent.yaml
@@ -1,0 +1,33 @@
+name: crowdsecurity/generic-no-user-agent
+description: "Protect against no user agent"
+rules:
+## Useragent header does not exist
+  - and:
+      - zones:
+        - METHOD
+        match:
+          type: regex
+          value: '^GET|POST|PUT|DELETE|PATCH$'
+      - zones:
+        - HEADERS
+        variables:
+         - "User-Agent"
+        transform:
+          - count
+        match:
+          type: equals
+          value: "0"
+
+
+
+    
+labels:
+   type: exploit
+   service: http
+   confidence: 2
+   spoofable: 0
+   behavior: "http:exploit"
+   label: "Protect against no user agent"
+   classification:
+     - attack.T1595
+     - attack.T1190

--- a/collections/crowdsecurity/appsec-generic-rules.yaml
+++ b/collections/crowdsecurity/appsec-generic-rules.yaml
@@ -5,7 +5,7 @@ appsec-rules:
   - crowdsecurity/generic-wordpress-uploads-php
   - crowdsecurity/generic-wordpress-uploads-listing
   - crowdsecurity/appsec-generic-test
-  - crowdsecurity/generic-no-user-agent
+  - crowdsecurity/experimental-no-user-agent
 appsec-configs:
   - crowdsecurity/generic-rules
   - crowdsecurity/appsec-default

--- a/collections/crowdsecurity/appsec-generic-rules.yaml
+++ b/collections/crowdsecurity/appsec-generic-rules.yaml
@@ -5,6 +5,7 @@ appsec-rules:
   - crowdsecurity/generic-wordpress-uploads-php
   - crowdsecurity/generic-wordpress-uploads-listing
   - crowdsecurity/appsec-generic-test
+  - crowdsecurity/generic-no-user-agent
 appsec-configs:
   - crowdsecurity/generic-rules
   - crowdsecurity/appsec-default

--- a/taxonomy/scenarios.json
+++ b/taxonomy/scenarios.json
@@ -28,6 +28,23 @@
     "service": "http",
     "created_at": "2024-03-28 17:01:19"
   },
+  "crowdsecurity/generic-no-user-agent": {
+    "name": "crowdsecurity/generic-no-user-agent",
+    "description": "Protect against no user agent",
+    "label": "Protect against no user agent",
+    "behaviors": [
+      "http:exploit"
+    ],
+    "mitre_attacks": [
+      "TA0043:T1595",
+      "TA0001:T1190"
+    ],
+    "confidence": 2,
+    "spoofable": 0,
+    "cti": true,
+    "service": "http",
+    "created_at": "2025-06-30 11:36:48"
+  },
   "crowdsecurity/generic-wordpress-uploads-listing": {
     "name": "crowdsecurity/generic-wordpress-uploads-listing",
     "description": "Protect Wordpress uploads directory from listing files",

--- a/taxonomy/scenarios.json
+++ b/taxonomy/scenarios.json
@@ -11,6 +11,23 @@
     "service": "http",
     "created_at": "2025-06-17 16:52:24"
   },
+  "crowdsecurity/experimental-no-user-agent": {
+    "name": "crowdsecurity/experimental-no-user-agent",
+    "description": "Protect against no user agent",
+    "label": "Protect against no user agent",
+    "behaviors": [
+      "http:exploit"
+    ],
+    "mitre_attacks": [
+      "TA0043:T1595",
+      "TA0001:T1190"
+    ],
+    "confidence": 2,
+    "spoofable": 0,
+    "cti": true,
+    "service": "http",
+    "created_at": "2025-06-30 11:36:48"
+  },
   "crowdsecurity/generic-freemarker-ssti": {
     "name": "crowdsecurity/generic-freemarker-ssti",
     "description": "Generic FreeMarker SSTI",
@@ -27,23 +44,6 @@
     "cti": true,
     "service": "http",
     "created_at": "2024-03-28 17:01:19"
-  },
-  "crowdsecurity/generic-no-user-agent": {
-    "name": "crowdsecurity/generic-no-user-agent",
-    "description": "Protect against no user agent",
-    "label": "Protect against no user agent",
-    "behaviors": [
-      "http:exploit"
-    ],
-    "mitre_attacks": [
-      "TA0043:T1595",
-      "TA0001:T1190"
-    ],
-    "confidence": 2,
-    "spoofable": 0,
-    "cti": true,
-    "service": "http",
-    "created_at": "2025-06-30 11:36:48"
   },
   "crowdsecurity/generic-wordpress-uploads-listing": {
     "name": "crowdsecurity/generic-wordpress-uploads-listing",

--- a/taxonomy/scenarios.json
+++ b/taxonomy/scenarios.json
@@ -22,7 +22,7 @@
       "TA0043:T1595",
       "TA0001:T1190"
     ],
-    "confidence": 2,
+    "confidence": 0,
     "spoofable": 0,
     "cti": true,
     "service": "http",


### PR DESCRIPTION
This rule detects if the incoming request has no useragent, typically you would combine this with an empty string check, however, nginx siliently drops empty headers so there no point having this plus nuclei makes this impossible to test 😓 .

Also HEAD requests by RFC do not need to send a usergent, hence these are omitted by the method check.