### PR TITLE
Update apache-guacamole-logs.yaml

### DIFF
--- a/parsers/s01-parse/corvese/apache-guacamole-logs.yaml
+++ b/parsers/s01-parse/corvese/apache-guacamole-logs.yaml
@@ -6,7 +6,7 @@ pattern_syntax:
   GUAC_CUSTOMUSER: "(%{EMAILADDRESS}|%{USERNAME})"
 nodes:
   - grok:
-      pattern: '%{TIMESTAMP_ISO8601:timestamp}.*Authentication attempt from \[%{IP:source_ip}.*for user "%{GUAC_CUSTOMUSER:username}" failed'
+      pattern: '%{TIMESTAMP_ISO8601:timestamp}.*Authentication attempt from \[?%{IP:source_ip}.*for user "%{GUAC_CUSTOMUSER:username}" failed'
       apply_on: message
       statics:
         - meta: log_type


### PR DESCRIPTION
Guacamole 1.6.0 does not always include [<IP>] in brackets, therefore changed this grok pattern to optionally check for the [

Example
 2025-07-03T13:40:08,658Z [http-nio-8080-exec-20] WARN  o.a.g.event.EventLoggingListener - Authentication attempt from 1.1.1.1 for user "xy" failed: Invalid login (rejected by "xy")
