### PR TITLE
Fix Jellyfin BF

### DIFF
--- a/scenarios/LePresidente/jellyfin-bf.yaml
+++ b/scenarios/LePresidente/jellyfin-bf.yaml
@@ -5,7 +5,7 @@ filter: "evt.Meta.log_type == 'jellyfin_failed_auth'"
 #debug: true
 type: leaky
 groupby: evt.Meta.source_ip
-leakspeed: "20s"
+leakspeed: 20s
 capacity: 5
 blackhole: 1m
 labels:
@@ -25,7 +25,7 @@ description: "Detect jellyfin user enum bruteforce"
 filter: "evt.Meta.log_type == 'jellyfin_failed_auth'"
 groupby: evt.Meta.source_ip
 distinct: evt.Meta.user
-leakspeed: 10s
+leakspeed: 1m
 capacity: 5
 blackhole: 1m
 labels:
@@ -36,5 +36,5 @@ labels:
   classification:
     - attack.T1589
     - attack.T1110
-  label: "Harbor User Enumeration"
+  label: "Jellyfin User Enumeration"
   remediation: true


### PR DESCRIPTION
Fix typo in user enum label. Fix user enum leakspeed is less than generic BF leakspeed causing user enum scenario to be impossible to trigger except at the exact same time as BF scenario.

The user enumeration BF scenario is distinct by username and should have a slower leakspeed in order for it to do anything. Otherwise, the generic BF scenario will always trigger first. This appears to be a typo as the .md file says the leakspeed on the user enumeration BF should be 1m.