### PR TITLE
Fix Authentik User Enum BF

### DIFF
--- a/scenarios/firix/authentik-bf.md
+++ b/scenarios/firix/authentik-bf.md
@@ -1,4 +1,4 @@
 Detect failed authentik authentications:
 
  - leakspeed of 20s, capacity of 5 on same target user
- - leakspeed of 10s, capacity of 5 unique distinct users
+ - leakspeed of 1m, capacity of 5 unique distinct users

--- a/scenarios/firix/authentik-bf.yaml
+++ b/scenarios/firix/authentik-bf.yaml
@@ -24,7 +24,7 @@ description: "Detect authentik user enum bruteforce"
 filter: evt.Meta.log_type in ['authentik_failed_auth', 'authentik_invalid_username']
 groupby: evt.Meta.source_ip
 distinct: evt.Meta.username
-leakspeed: 10s
+leakspeed: 1m
 capacity: 5
 blackhole: 1m
 labels:


### PR DESCRIPTION
Fix user enum leakspeed is less than generic BF leakspeed causing user enum scenario to be impossible to trigger except at the exact same time as BF scenario.

The user enumeration BF scenario is distinct by username and should have a slower leakspeed in order for it to do anything. Otherwise, the generic BF scenario will always trigger first. This may be a typo that was copied over and then the .md corrected instead of the scenario itself. See #1411 as an example.