### PR TITLE
Fix Jellyseerr user enum BF and add Jellyseerr whitelist

### DIFF
--- a/collections/LePresidente/jellyseerr.yml
+++ b/collections/LePresidente/jellyseerr.yml
@@ -1,5 +1,6 @@
 parsers:
   - LePresidente/jellyseerr-logs
+  - crowdsecurity/jellyseerr-whitelist
 scenarios:
   - LePresidente/jellyseerr-bf
 description: "jellyseerr Support : parser and brute-force detection"

--- a/parsers/s02-enrich/crowdsecurity/jellyseerr-whitelist.md
+++ b/parsers/s02-enrich/crowdsecurity/jellyseerr-whitelist.md
@@ -1,0 +1,4 @@
+## Jellyseerr Whitelist
+
+### Browsing Movies, Series or Requests
+When scrolling fast while using Jellyseerr on the Movies, Series or Requests pages, many GET requests are made to ``/api/v1/(movie|tv|request)``. The http-crawl-non_statics scenario will be triggered if too many requests to the API are made too quickly unless this whitelist is used. 

--- a/parsers/s02-enrich/crowdsecurity/jellyseerr-whitelist.yaml
+++ b/parsers/s02-enrich/crowdsecurity/jellyseerr-whitelist.yaml
@@ -1,0 +1,7 @@
+name: crowdsecurity/jellyseerr-whitelist
+description: "Whitelist events from jellyseerr"
+filter: "evt.Meta.service == 'http' && evt.Meta.log_type in ['http_access-log', 'http_error-log']"
+whitelist:
+  reason: "Jellyseerr whitelist"
+  expression:
+   - evt.Meta.http_status in ['200', '304', '499'] && evt.Parsed.static_ressource == 'false' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path matches '\\/api\\/v1\\/(movie|tv|request)\\/(\\d+)' # When browsing Movies, Series or Requests

--- a/scenarios/LePresidente/jellyseerr-bf.yaml
+++ b/scenarios/LePresidente/jellyseerr-bf.yaml
@@ -5,7 +5,7 @@ filter: "evt.Meta.log_type == 'jellyseerr_failed_auth'"
 #debug: true
 type: leaky
 groupby: evt.Meta.source_ip
-leakspeed: "20s"
+leakspeed: 20s
 capacity: 5
 blackhole: 1m
 labels:
@@ -25,7 +25,7 @@ description: "Detect jellyseerr user enum bruteforce"
 filter: "evt.Meta.log_type == 'jellyseerr_failed_auth'"
 groupby: evt.Meta.source_ip
 distinct: evt.Meta.user
-leakspeed: 10s
+leakspeed: 1m
 capacity: 5
 blackhole: 1m
 labels:


### PR DESCRIPTION
Fix user enum leakspeed is less than generic BF leakspeed causing user enum scenario to be impossible to trigger except at the exact same time as BF scenario. Add Jellyseerr whitelist to prevent http-crawl-non_statics false positives which will fix #1123.

The user enumeration BF scenario is distinct by username and should have a slower leakspeed in order for it to do anything. Otherwise, the generic BF scenario will always trigger first. This appears to be a typo as the .md file says the leakspeed on the user enumeration BF should be 1m.

Add Jellyseerr whitelist which works for me and others locally as mentioned in #1123. I added it to the Jellyseerr collection in this PR but I am not sure how to add tests for it. Looking for help if tests are needed.