### PR TITLE
feat: Add WAF rule for CVE-2025-57819 (FreePBX RCE)

### DIFF
--- a/.appsec-tests/CVE-2025-57819/CVE-2025-57819.yaml
+++ b/.appsec-tests/CVE-2025-57819/CVE-2025-57819.yaml
@@ -1,0 +1,20 @@
+id: CVE-2025-57819
+info:
+  name: CVE-2025-57819
+  author: crowdsec
+  severity: info
+  description: CVE-2025-57819 testing
+  tags: appsec-testing
+http:
+  - raw:
+    - |
+      GET /admin/ajax.php?module=FreePBX%5Cmodules%5Cendpoint%5Cajax&command=model&template=x&model=model&brand=x'%20;INSERT%20INTO%20cron_jobs%20(modulename,jobname,command,class,schedule,max_runtime,enabled,execution_order)%20VALUES%20('sysadmin','test','echo%20test',NULL,'* * * * *',30,1,1)%20--%20 HTTP/1.1
+      Host: {{Hostname}}
+      User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
+
+    cookie-reuse: true
+    matchers:
+    - type: dsl
+      condition: and
+      dsl:
+        - 'status_code_1 == 403'

--- a/.appsec-tests/CVE-2025-57819/config.yaml
+++ b/.appsec-tests/CVE-2025-57819/config.yaml
@@ -1,0 +1,3 @@
+appsec-rules:
+- ./appsec-rules/crowdsecurity/vpatch-CVE-2025-57819.yaml
+nuclei_template: CVE-2025-57819.yaml

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-57819.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-57819.yaml
@@ -1,0 +1,50 @@
+name: crowdsecurity/vpatch-CVE-2025-57819
+description: "FreePBX Remote Code Execution (CVE-2025-57819)"
+rules:
+  - and:
+    - zones:
+      - URI
+      match:
+        type: contains
+        value: "/admin/ajax.php"
+    - zones:
+      - ARGS
+      variables:
+      - module
+      transform:
+      - urldecode
+      match:
+        type: contains
+        value: "FreePBX\\modules\\endpoint\\ajax"
+    - zones:
+      - ARGS
+      variables:
+      - command
+      match:
+        type: equals
+        value: "model"
+    - zones:
+      - ARGS
+      variables:
+      - brand
+      transform:
+      - urldecode
+      - lowercase
+      match:
+        type: regex
+        value: "[';]\\s*(insert|update|delete|drop|create|alter)(\\s|/\\*\\*/)*\\s+"
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: "http:exploit"
+  label: "FreePBX Remote Code Execution - CVE-2025-57819"
+  classification:
+   - cve.CVE-2025-57819
+   - attack.T1595
+   - attack.T1190
+   - attack.T1059
+   - cwe.CWE-89
+   - cwe.CWE-707
+

--- a/collections/crowdsecurity/appsec-virtual-patching.yaml
+++ b/collections/crowdsecurity/appsec-virtual-patching.yaml
@@ -106,6 +106,7 @@ appsec-rules:
 - crowdsecurity/vpatch-CVE-2025-25257
 - crowdsecurity/vpatch-CVE-2019-5418
 - crowdsecurity/vpatch-CVE-2025-52488
+- crowdsecurity/vpatch-CVE-2025-57819
 - crowdsecurity/vpatch-CVE-2025-49132
 - crowdsecurity/vpatch-CVE-2025-47812
 - crowdsecurity/vpatch-CVE-2024-51977


### PR DESCRIPTION
- Add vpatch-CVE-2025-57819.yaml WAF rule to detect SQL injection in FreePBX endpoint module
- Rule detects malicious brand parameter containing SQL keywords after URL decoding and case normalization
- Includes nuclei test case for validation
- Add rule to appsec-virtual-patching collection
- Handles common evasion techniques: URL encoding, case variations, and comment injection