### PR TITLE
Added Traefik case for http-open-proxy probing

### DIFF
--- a/scenarios/crowdsecurity/http-open-proxy.yaml
+++ b/scenarios/crowdsecurity/http-open-proxy.yaml
@@ -1,8 +1,8 @@
 type: trigger
 name: crowdsecurity/http-open-proxy
 description: "Detect scan for open proxy"
-#apache returns 405, nginx 400
-filter: "evt.Meta.log_type == 'http_access-log' && evt.Meta.http_status in ['400','405'] && (evt.Parsed.verb == 'CONNECT' || evt.Parsed.request matches '^http[s]?://')"
+#apache returns 405, nginx 400, traefik 404
+filter: "evt.Meta.log_type == 'http_access-log' && evt.Meta.http_status in ['400','405','404'] && (evt.Parsed.verb == 'CONNECT' || evt.Parsed.request matches '^http[s]?://')"
 blackhole: 2m
 groupby: evt.Meta.source_ip
 labels:


### PR DESCRIPTION
I have Traefik with logs like
```
45.95.147.173 - - [20/Sep/2025:19:06:16 +0000] "CONNECT / HTTP/1.1" 404 19 "-" "Go-http-client/1.1" 8820 "-" "-" 0ms
```
It should be banned by `http-open-proxy` scenarion, but it does not, because scenario processes only responses with HTTP 405 and 400. Traefik returns 404.

Example log line do not fall into `http-open-proxy` scenario:
```
# cscli explain --log '45.95.147.173 - - [20/Sep/2025:19:06:16 +0000] "CONNECT / HTTP/1.1" 404 19 "-" "Go-http-client/1.1" 8820 "-" "-" 0ms' --
type traefik
line: 45.95.147.173 - - [20/Sep/2025:19:06:16 +0000] "CONNECT / HTTP/1.1" 404 19 "-" "Go-http-client/1.1" 8820 "-" "-" 0ms
        ├ s00-raw
        |       ├ � crowdsecurity/cri-logs
        |       ├ � crowdsecurity/docker-logs
        |       ├ � crowdsecurity/syslog-logs
        |       └ � crowdsecurity/non-syslog ( +5 ~8)
        ├ s01-parse
        |       ├ � crowdsecurity/sshd-logs
        |       └ � crowdsecurity/traefik-logs ( +24 ~2)
        ├ s02-enrich
        |       ├ � crowdsecurity/dateparse-enrich ( +2 ~2)
        |       ├ � crowdsecurity/geoip-enrich ( +13)
        |       ├ � crowdsecurity/http-logs ( +6)
        |       ├ � crowdsecurity/public-dns-allowlist ( unchanged)
        |       └ � crowdsecurity/whitelists ( unchanged)
        ├-------- parser success �
        ├ Scenarios
                └ � crowdsecurity/http-probing
```

If I change error to 405 in the log line (for testing purpose), then it works as intended:
```
# cscli explain --log '45.95.147.173 - - [20/Sep/2025:19:06:16 +0000] "CONNECT / HTTP/1.1" 405 19 "-" "Go-http-client/1.1" 8820 "-" "-" 0ms' --
type traefik
line:
        ├ s00-enrich
        |       └ � crowdsecurity/rdns ( +68 ~6)
        ├ s01-whitelist
        |       ├ � crowdsecurity/cdn-whitelist ( unchanged)
        |       └ � crowdsecurity/seo-bots-whitelist ( unchanged)
        └-------- parser failure �

line: 45.95.147.173 - - [20/Sep/2025:19:06:16 +0000] "CONNECT / HTTP/1.1" 405 19 "-" "Go-http-client/1.1" 8820 "-" "-" 0ms
        ├ s00-raw
        |       ├ � crowdsecurity/cri-logs
        |       ├ � crowdsecurity/docker-logs
        |       ├ � crowdsecurity/syslog-logs
        |       └ � crowdsecurity/non-syslog ( +5 ~8)
        ├ s01-parse
        |       ├ � crowdsecurity/sshd-logs
        |       └ � crowdsecurity/traefik-logs ( +24 ~2)
        ├ s02-enrich
        |       ├ � crowdsecurity/dateparse-enrich ( +2 ~2)
        |       ├ � crowdsecurity/geoip-enrich ( +13)
        |       ├ � crowdsecurity/http-logs ( +6)
        |       ├ � crowdsecurity/public-dns-allowlist ( unchanged)
        |       └ � crowdsecurity/whitelists ( unchanged)
        ├-------- parser success �
        ├ Scenarios
                └ � crowdsecurity/http-open-proxy
```

This PR adds HTTP 404 status code to the scenario conditions.

---

Traefik 3.3.6, Crowdsec 1.7.0, K3s 1.33.4.