### PR TITLE
Adding support for MailScanner

### DIFF
--- a/.tests/mailscanner-spam/config.yaml
+++ b/.tests/mailscanner-spam/config.yaml
@@ -1,0 +1,14 @@
+parsers:
+- crowdsecurity/syslog-logs
+- ./parsers/s01-parse/cbrandlehner/mailscanner-spam.yaml
+- ./parsers/s01-parse/cbrandlehner/mailscanner-spam-blacklist.yaml
+- crowdsecurity/dateparse-enrich
+#- crowdsecurity/geoip-enrich
+scenarios:
+- ./scenarios/cbrandlehner/mailscanner-highscore.yaml
+- ./scenarios/cbrandlehner/mailscanner-blacklist.yaml
+postoverflows:
+- ""
+log_file: mailscanner-spam.log
+log_type: syslog
+ignore_parsers: false

--- a/.tests/mailscanner-spam/mailscanner-spam.log
+++ b/.tests/mailscanner-spam/mailscanner-spam.log
@@ -1,0 +1,2 @@
+Jul 30 08:01:07 efa MailScanner[1803828]: Message 4bsM5k4xJmz4rT6 from 66.187.204.154 (bounces@enbounce.hsi-europe.org) to brandlehner.at is spam, SpamAssassin (not cached, score=7.181, required 4, BAYES_40 -0.20, DKIM_SIGNED 0.01, DKIM_VALID -0.21, DKIM_VALID_AU -0.21
+

--- a/.tests/mailscanner-spam/parser.assert
+++ b/.tests/mailscanner-spam/parser.assert
@@ -1,0 +1,55 @@
+len(results) == 4
+len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 1
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Success == true
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["logsource"] == "syslog"
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["message"] == "Message 4bsM5k4xJmz4rT6 from 66.187.204.154 (bounces@enbounce.hsi-europe.org) to brandlehner.at is spam, SpamAssassin (not cached, score=7.181, required 4, BAYES_40 -0.20, DKIM_SIGNED 0.01, DKIM_VALID -0.21, DKIM_VALID_AU -0.21"
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["pid"] == "1803828"
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["program"] == "MailScanner"
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["timestamp"] == "Jul 30 08:01:07"
+basename(results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Meta["datasource_path"]) == "mailscanner-spam.log"
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Meta["datasource_type"] == "file"
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Meta["machine"] == "efa"
+results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Whitelisted == false
+len(results["s01-parse"]["cbrandlehner/mailscanner-spam"]) == 1
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Success == true
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["from_email"] == "bounces@enbounce.hsi-europe.org"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["logsource"] == "syslog"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["message"] == "Message 4bsM5k4xJmz4rT6 from 66.187.204.154 (bounces@enbounce.hsi-europe.org) to brandlehner.at is spam, SpamAssassin (not cached, score=7.181, required 4, BAYES_40 -0.20, DKIM_SIGNED 0.01, DKIM_VALID -0.21, DKIM_VALID_AU -0.21"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["message_id"] == "4bsM5k4xJmz4rT6"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["pid"] == "1803828"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["program"] == "MailScanner"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["rawmessage"] == "Jul 30 08:01:07 efa MailScanner[1803828]: Message 4bsM5k4xJmz4rT6 from 66.187.204.154 (bounces@enbounce.hsi-europe.org) to brandlehner.at is spam, SpamAssassin (not cached, score=7.181, required 4, BAYES_40 -0.20, DKIM_SIGNED 0.01, DKIM_VALID -0.21, DKIM_VALID_AU -0.21"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["source_ip"] == "66.187.204.154"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["spam_score"] == "7.181000"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["timestamp"] == "Jul 30 08:01:07"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Parsed["to_domain"] == "brandlehner.at"
+basename(results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Meta["datasource_path"]) == "mailscanner-spam.log"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Meta["log_type"] == "mailscanner_spam"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Meta["machine"] == "efa"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Meta["source_ip"] == "66.187.204.154"
+results["s01-parse"]["cbrandlehner/mailscanner-spam"][0].Evt.Whitelisted == false
+len(results["s01-parse"]["cbrandlehner/mailscanner-spam-blacklist"]) == 1
+results["s01-parse"]["cbrandlehner/mailscanner-spam-blacklist"][0].Success == false
+len(results["s02-enrich"]["crowdsecurity/dateparse-enrich"]) == 1
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Success == true
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["from_email"] == "bounces@enbounce.hsi-europe.org"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["logsource"] == "syslog"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["message"] == "Message 4bsM5k4xJmz4rT6 from 66.187.204.154 (bounces@enbounce.hsi-europe.org) to brandlehner.at is spam, SpamAssassin (not cached, score=7.181, required 4, BAYES_40 -0.20, DKIM_SIGNED 0.01, DKIM_VALID -0.21, DKIM_VALID_AU -0.21"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["message_id"] == "4bsM5k4xJmz4rT6"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["pid"] == "1803828"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["program"] == "MailScanner"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["rawmessage"] == "Jul 30 08:01:07 efa MailScanner[1803828]: Message 4bsM5k4xJmz4rT6 from 66.187.204.154 (bounces@enbounce.hsi-europe.org) to brandlehner.at is spam, SpamAssassin (not cached, score=7.181, required 4, BAYES_40 -0.20, DKIM_SIGNED 0.01, DKIM_VALID -0.21, DKIM_VALID_AU -0.21"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["source_ip"] == "66.187.204.154"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["spam_score"] == "7.181000"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["timestamp"] == "Jul 30 08:01:07"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Parsed["to_domain"] == "brandlehner.at"
+basename(results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Meta["datasource_path"]) == "mailscanner-spam.log"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Meta["datasource_type"] == "file"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Meta["log_type"] == "mailscanner_spam"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Meta["machine"] == "efa"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Meta["source_ip"] == "66.187.204.154"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Meta["timestamp"] == "2025-07-30T08:01:07Z"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Enriched["MarshaledTime"] == "2025-07-30T08:01:07Z"
+results["s02-enrich"]["crowdsecurity/dateparse-enrich"][0].Evt.Whitelisted == false
+len(results["success"][""]) == 0

--- a/.tests/mailscanner-spam/scenario.assert
+++ b/.tests/mailscanner-spam/scenario.assert
@@ -1,0 +1,2 @@
+len(results) == 0
+

--- a/collections/cbrandlehner/mailscanner.md
+++ b/collections/cbrandlehner/mailscanner.md
@@ -1,0 +1,48 @@
+# MailScanner Parser & Scenarios for CrowdSec
+
+## Overview
+
+This package integrates [MailScanner](https://www.mailscanner.info/) logs — including those used in the [Email Filter Appliance (E.F.A.)](https://efa-project.org) project — with CrowdSec.  
+
+It provides:
+
+- Two parsers to normalize MailScanner log entries.
+- Two scenarios to detect and react to spam messages:
+  - Blacklisted senders
+  - High-scoring spam (spam_score > 20.0)
+
+These components allow CrowdSec to automatically ban source IPs that MailScanner has already flagged as spammers.
+
+---
+
+## Components
+
+### Parsers
+- **`cbrandlehner/mailscanner-spam-blacklist`**
+  - Extracts fields such as `source_ip`and `spam_reason`.
+  - Sets `evt.Meta.log_type` to value `mailscanner_blacklist`.
+
+- **`cbrandlehner/mailscanner-spam`**
+  - Extracts fields such as `source_ip` and `spam_score`.
+  - Sets `evt.Meta.log_type` to value `mailscanner_spam`.
+
+### Scenarios
+1. **`cbrandlehner/mailscanner-blacklisted`**
+   - **Type**: `trigger`
+   - Detects when `spam_reason == "blacklisted"`.
+   - Immediately raises an alert, grouped by `source_ip`.
+   - Labels the behavior as `smtp:spam`.
+
+2. **`cbrandlehner/mailscanner-highscore-spam`**
+   - **Type**: `leaky`
+   - Detects when `spam_score > 20.0` in MailScanner logs (`evt.Meta.log_type == "mailscanner_spam"`).
+   - Uses a leaky bucket: 1 event in 10s is enough to trigger, then silenced for 5m (via `blackhole`).
+   - Labels the behavior as `smtp:spam`.
+
+---
+
+## Example Log Lines
+
+```text
+Sep 29 04:00:57 efa MailScanner[2129202]: Message 4cZktc2W3sz3bl4 from 85.17.179.32 (akkitbz@cobusan.com.tr) to brandlehner.at is spam (blacklisted)
+Sep 29 10:28:25 efa MailScanner[2324063]: Message 4cZvTc05hqz3dT5 from 88.99.6.69 (nr136@rp.news.newsletter2.louis.de) to bechelaren.at is spam, SpamAssassin (nicht zwischen gespeichert, Wertung=11.11, benoetigt 4, BAYES_40 -0.20, DCC_CHECK 1.10, DKIM_SIGNED 0.01, DKIM_VALID -0.10, DMARC_PASS -0.00, HTML_FONT_LOW_CONTRAST 0.50, HTML_MESSAGE 0.00, MIME_HTML_ONLY 0.01, RCVD_IN_DNSWL_NONE -0.01, SPF_HELO_PASS -0.10, SPF_PASS -0.10, ZTL_RECEIVED_IP_LR_V1 10.00, ZTL_RELAYCOUNTRY_NOT_AT 2.50, ZTL_RELAYCOUNTRY_USA_DE_CH -2.50)

--- a/collections/cbrandlehner/mailscanner.yml
+++ b/collections/cbrandlehner/mailscanner.yml
@@ -1,0 +1,12 @@
+parsers:
+  - cbrandlehner/mailscanner-spam-blacklist
+  - cbrandlehner/mailscanner-spam
+scenarios:
+  - cbrandlehner/mailscanner-blacklisted
+  - cbrandlehner/mailscanner-highscore-spam
+description: "mailscanner support : parser and spammer detection"
+author: cbrandlehner
+tags:
+  - linux
+  - spam
+  - mail

--- a/parsers/s01-parse/cbrandlehner/mailscanner-spam-blacklist.yaml
+++ b/parsers/s01-parse/cbrandlehner/mailscanner-spam-blacklist.yaml
@@ -1,0 +1,19 @@
+name: cbrandlehner/mailscanner-spam-blacklist
+description: Parse MailScanner spam logs for blacklisted senders
+onsuccess: next_stage
+filter: "evt.Parsed.program == 'MailScanner'"
+grok:
+  pattern: 'Message %{NOTSPACE:message_id} from %{IP:source_ip} \(%{EMAILADDRESS:from_email}\) to %{NOTSPACE:to_domain} is spam \(%{WORD:spam_reason}\)'
+  apply_on: message
+statics:
+  - meta: log_type
+    value: mailscanner_blacklist
+  - meta: source_ip
+    expression: evt.Parsed.source_ip
+  - parsed: source_ip
+    expression: evt.Parsed.source_ip
+  - parsed: spam_reason
+    expression: evt.Parsed.spam_reason
+  - parsed: rawmessage
+    expression: evt.Line.Raw
+

--- a/parsers/s01-parse/cbrandlehner/mailscanner-spam.yaml
+++ b/parsers/s01-parse/cbrandlehner/mailscanner-spam.yaml
@@ -1,0 +1,19 @@
+name: cbrandlehner/mailscanner-spam
+description: Parse MailScanner spam logs
+onsuccess: next_stage
+filter: "evt.Parsed.program == 'MailScanner'"
+grok:
+  pattern: 'Message %{NOTSPACE:message_id} from %{IP:source_ip} \(%{EMAILADDRESS:from_email}\) to %{NOTSPACE:to_domain} is spam.*(score|Wertung)=%{NUMBER:spam_score}'
+  apply_on: message
+statics:
+  - meta: log_type
+    value: mailscanner_spam
+  - meta: source_ip
+    expression: evt.Parsed.source_ip
+  - parsed: source_ip
+    expression: evt.Parsed.source_ip
+  - parsed: spam_score
+    expression: float(evt.Parsed.spam_score)
+  - parsed: rawmessage
+    expression: evt.Line.Raw
+

--- a/scenarios/cbrandlehner/mailscanner-blacklist.yaml
+++ b/scenarios/cbrandlehner/mailscanner-blacklist.yaml
@@ -1,0 +1,15 @@
+name: cbrandlehner/mailscanner-blacklisted
+description: Detects MailScanner logs where a message is marked as spam due to blacklisting
+type: trigger
+filter: "evt.Meta.log_type == 'mailscanner_blacklist' && evt.Parsed.spam_reason == 'blacklisted'"
+groupby: evt.Parsed.source_ip
+blackhole: 5m
+labels:
+  type: spam
+  remediation: true
+  behavior: "smtp:spam"
+  spoofable: 0
+  confidence: 2
+  label: "MailScanner detected an SMTP message from an blacklisted sender"
+  service: smtp
+

--- a/scenarios/cbrandlehner/mailscanner-highscore.yaml
+++ b/scenarios/cbrandlehner/mailscanner-highscore.yaml
@@ -1,0 +1,17 @@
+name: cbrandlehner/mailscanner-highscore-spam
+description: Detects spam messages in MailScanner logs with score > 20.0
+type: leaky
+filter: "evt.Meta.log_type == 'mailscanner_spam' && float(evt.Parsed.spam_score) > 20.0"
+groupby: evt.Parsed.source_ip
+leakspeed: 10s
+capacity: 1
+blackhole: 5m
+labels:
+  type: spam
+  remediation: true
+  behavior: "smtp:spam"
+  spoofable: 0
+  confidence: 1
+  label: "MailScanner classifed an SMTP email as SPAM with a spam_score higher 20"
+  service: smtp
+


### PR DESCRIPTION
This package integrates [MailScanner](https://www.mailscanner.info/) logs — including those used in the [Email Filter Appliance (E.F.A.)](https://efa-project.org) project — with CrowdSec.  

It provides:

- Two parsers to normalize MailScanner log entries.
- Two scenarios to detect and react to spam messages:
  - Blacklisted senders
  - High-scoring spam (spam_score > 20.0)

These components allow CrowdSec to automatically ban source IPs that MailScanner has already flagged as spammers.
