### PR TITLE
http context: add domain for WAF match

### DIFF
--- a/contexts/crowdsecurity/http_extended.yaml
+++ b/contexts/crowdsecurity/http_extended.yaml
@@ -2,3 +2,4 @@
 context:
   target_fqdn:
   - evt.Meta.target_fqdn
+  - "req != nil ? req.Host : ''"


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

Add the target domain in the extended HTTP context for WAF match (metas are not passed to the context evaluation for a WAF match, only the matched rules and the HTTP request)

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [ ] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [ ] I have tested my changes locally
 - [ ] For new parsers or scenarios, tests have been added 
 - [ ] I have run the hub linter and no issues were reported (see contributing guide)
 - [ ] Automated tests are passing
 - [ ] AI was used to generate any/all content of this PR