### PR TITLE
remove broken badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 </p>
 </br>
 <p align="center">
-<img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AlteredCoder/ed74e50c43e3b17bdfc4d93149f23d37/raw/hub_parsers_badge.json">
-<img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AlteredCoder/ed74e50c43e3b17bdfc4d93149f23d37/raw/hub_scenarios_badge.json">
-<img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/AlteredCoder/ed74e50c43e3b17bdfc4d93149f23d37/raw/hub_appsec_badge.json">
 </p>
 
 <p align="center">


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description


Remove badges from Readme. It seems that the `cscli hubtest coverage` command is broken (at least I wasn't able to make it work locally).

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [x] For new parsers or scenarios, tests have been added 
 - [ ] I have run the hub linter and no issues were reported (see contributing guide)
 - [x] Automated tests are passing
 - [ ] AI was used to generate any/all content of this PR