### PR TITLE
fix: pf-logs IPv6 service detection using empty string check

### DIFF
--- a/parsers/s01-parse/firewallservices/pf-logs.yaml
+++ b/parsers/s01-parse/firewallservices/pf-logs.yaml
@@ -39,7 +39,7 @@ description: "Identify dropped packets"
 onsuccess: next_stage
 statics:
   - meta: service
-    expression: "evt.Parsed.ip4_proto != nil ? evt.Parsed.ip4_proto : evt.Parsed.ip6_proto"
+    expression: "Lower(evt.Parsed.ip4_proto != '' ? evt.Parsed.ip4_proto : evt.Parsed.ip6_proto)"
   - meta: log_type
     value: pf_drop
   - meta: source_ip


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

pf-logs IPv6 service detection using empty string check

parsed variables are never nil so it was never setting ipv6 proto if it was available also it seems to be uppercase so wrapping in lower function to ensure it always lowercase.

<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [x] For new parsers or scenarios, tests have been added 
 - [x] I have run the hub linter and no issues were reported (see contributing guide)
 - [x] Automated tests are passing
 - [x] AI was used to generate any/all content of this PR