### PR TITLE
Change variable from $msg to $rawmsg in ruleset

### DIFF
--- a/collections/crowdsecurity/unifi.md
+++ b/collections/crowdsecurity/unifi.md
@@ -52,7 +52,7 @@ input(
 )
 
 ruleset(name="unifi") {
-    if $msg startswith "CEF:" then {
+    if $rawmsg startswith "CEF:" then {
         action(type="omfile" file="/var/log/unifi-cef.log" template="CEF")
     } else {
         action(type="omfile" file="/var/log/unifi-syslog.log" template="Syslog")


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

Update unifi readme with `$rawmsg` instead of `$msg` as it doesnt contain CEF by default

<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [x] For new parsers or scenarios, tests have been added 
 - [x] I have run the hub linter and no issues were reported (see contributing guide)
 - [x] Automated tests are passing
 - [ ] AI was used to generate any/all content of this PR