### PR TITLE
Add custom parser for Pi-hole logs on ARM/Armbian (dnsmasq v6 format)

### DIFF
--- a/parsers/s01-parse/custom-pihole-logs.yaml
+++ b/parsers/s01-parse/custom-pihole-logs.yaml
@@ -1,0 +1,13 @@
+name: custom/pihole-logs
+description: Parser for Pi-hole logs on ARM/Armbian (dnsmasq/syslog format)
+filter: "evt.Line.Labels.type == 'pihole'"
+onsuccess: next_stage
+
+pattern_syntax:
+  SYSLOGDATE: '[A-Z][a-z]{2} +[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2}'
+
+nodes:
+  - grok:
+      pattern: "%{SYSLOGDATE:timestamp} %{WORD:process}\\[%{NUMBER:pid}\\]: %{GREEDYDATA:message}"
+      apply_on: message
+


### PR DESCRIPTION
This parser adds support for Pi-hole v6 log format on ARM/Armbian devices, where dnsmasq writes logs directly into /var/log/pihole/*.log instead of syslog/journalctl.

Currently, CrowdSec Hub has no parser capable of handling Pi-hole v6 logs, so CrowdSec cannot ingest DNS queries, FTL events, or webserver logs on ARM boards.

This parser uses a syslog-style GROK pattern compatible with dnsmasq outputs on Pi-hole v6 and has been tested successfully on Radxa Zero 3 (Armbian) with CrowdSec 1.6.

The objective is to help ARM users integrate Pi-hole into CrowdSec without manually creating custom parsers and to make this parser available via Hub so future installations can auto-install it.

<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [ ] For new parsers or scenarios, tests have been added 
 - [ ] I have run the hub linter and no issues were reported (see contributing guide)
 - [ ] Automated tests are passing
 - [x] AI was used to generate any/all content of this PR