### PR TITLE
Change Vaultwarden label to syslog

### DIFF
--- a/collections/Dominic-Wagner/vaultwarden.md
+++ b/collections/Dominic-Wagner/vaultwarden.md
@@ -21,7 +21,7 @@ source: journalctl
 journalctl_filter:
   - "SYSLOG_IDENTIFER=Vaultwarden"
 labels:
-  type: Vaultwarden
+  type: syslog
 ```
 
 ## Timestamp issues


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

Change example acquis to `syslog` in vaultwarden since we need to strip syslog prefix

<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [x] For new parsers or scenarios, tests have been added 
 - [x] I have run the hub linter and no issues were reported (see contributing guide)
 - [x] Automated tests are passing
 - [ ] AI was used to generate any/all content of this PR