### PR TITLE
Remove whitelist-good-actors from linux.yaml

### DIFF
--- a/collections/crowdsecurity/linux.yaml
+++ b/collections/crowdsecurity/linux.yaml
@@ -4,7 +4,6 @@ parsers:
   - crowdsecurity/dateparse-enrich
 collections:
   - crowdsecurity/sshd
-  - crowdsecurity/whitelist-good-actors
 description: "core linux support : syslog+geoip+ssh"
 author: crowdsecurity
 tags:


### PR DESCRIPTION
linux is a core collection: "core linux support : syslog+geoip+ssh". It should not contain crowdsecurity/whitelist-good-actors !!!

Moreover, whitelist-good-actors contain wrong actor which don't respect robots.txt.
And it added recently.

All whitelist should be add manually by server's administrator, not in core collection.

<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [ X] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [ X] I have tested my changes locally
 - [ X] For new parsers or scenarios, tests have been added 
 - [ X] I have run the hub linter and no issues were reported (see contributing guide)
 - [ X] Automated tests are passing
 - [ X] AI was used to generate any/all content of this PR