### PR TITLE
fix: vaultwarden syslog identifier typo and case

### DIFF
--- a/collections/Dominic-Wagner/vaultwarden.md
+++ b/collections/Dominic-Wagner/vaultwarden.md
@@ -19,7 +19,7 @@ If running via systemd:
 ---
 source: journalctl
 journalctl_filter:
-  - "SYSLOG_IDENTIFER=Vaultwarden"
+  - "SYSLOG_IDENTIFIER=vaultwarden"
 labels:
   type: syslog
 ```

--- a/parsers/s01-parse/Dominic-Wagner/vaultwarden-logs.md
+++ b/parsers/s01-parse/Dominic-Wagner/vaultwarden-logs.md
@@ -13,7 +13,7 @@ If running via systemd:
 ---
 source: journalctl
 journalctl_filter:
-  - "SYSLOG_IDENTIFER=Vaultwarden"
+  - "SYSLOG_IDENTIFIER=vaultwarden"
 labels:
   type: Vaultwarden
 ```


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

Fix SYSLOG_IDENTIFIER typo and use lowercase value

<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [x] For new parsers or scenarios, tests have been added 
 - [x] I have run the hub linter and no issues were reported (see contributing guide)
 - [x] Automated tests are passing
 - [x] AI was used to generate any/all content of this PR