### PR TITLE
plex-allowlist: add modern client API endpoints

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/plex-allowlist.md
+++ b/parsers/s02-enrich/crowdsecurity/plex-allowlist.md
@@ -2,4 +2,5 @@
 
 Allowlist for Plex Media Server.
 
-Allow events on the various transcode endpoints, timeline scrubbing and library metadata.
+Allow events on the various transcode endpoints, timeline scrubbing, library metadata,
+and standard client API calls (hubs, library browsing, search, playlists, activities).

--- a/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
+++ b/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
@@ -12,3 +12,10 @@ whitelist:
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/playQueues/'
    - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'POST' && evt.Parsed.request == '/log' && evt.Parsed.http_args contains 'X-Plex-Product=Plex%20Cast&X-Plex-Version='
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/music/:/transcode/universal/session/'
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/hubs/' # Home screen content hubs
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path == '/activities' # Background activity monitoring
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/library/sections/' # Library section browsing
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/library/all' # Browse all items
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/library/search' # Search functionality
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/playlists/' # Playlist management
+   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/media/providers' # Media provider config


### PR DESCRIPTION
## Description

Add allowlist rules for modern Plex client API endpoints to prevent false positives
with `http-crawl-non_statics` scenario.

**Problem**: Modern Plex clients (iOS, tvOS, Android, web) make rapid API calls when
users browse their libraries. These legitimate requests trigger crawl detection.

**Evidence**: Apple TV user (PlexTV/8.45) was banned after 43 requests in 16 seconds
while browsing their library. Investigation confirmed this was a legitimate user and
device with no suspicious activity - all requests were standard Plex API calls.

**New endpoints covered**:
- `/hubs/*` - Home screen content hubs
- `/activities` - Background activity monitoring
- `/library/sections/*` - Library section browsing
- `/library/all` - Browse all items matching criteria
- `/library/search` - Search functionality
- `/playlists/*` - Playlist management
- `/media/providers` - Media provider configuration

Reference: https://github.com/Arcanemagus/plex-api/wiki

## Checklist
- [x] I have read the contributing guide
- [x] I have tested my changes locally
- [x] For new parsers or scenarios, tests have been added (N/A - updating existing)
- [x] I have run the hub linter and no issues were reported
- [x] Automated tests are passing
- [x] AI was used to generate any/all content of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)