### PR TITLE
fix(home-assistant): add 'hass' to program filter

### DIFF
--- a/parsers/s01-parse/crowdsecurity/home-assistant-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/home-assistant-logs.yaml
@@ -1,7 +1,7 @@
 onsuccess: next_stage
 name: crowdsecurity/home-assistant-logs
 description: "Parse Home Assistant logs"
-filter: "evt.Parsed.program == 'home-assistant' or evt.Parsed.program endsWith 'homeassistant'"
+filter: "evt.Parsed.program in ['home-assistant', 'hass'] or evt.Parsed.program endsWith 'homeassistant'"
 pattern_syntax:
   TIMESTAMP: '%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}'
 nodes:


### PR DESCRIPTION
Fixes #1648

<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

Add 'hass' as a recognized program name in the home-assistant-logs parser filter, as it's a well-known abbreviation used by NixOS setups.


<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [x] For new parsers or scenarios, tests have been added 
 - [x] I have run the hub linter and no issues were reported (see contributing guide)
 - [x] Automated tests are passing
 - [x] AI was used to generate any/all content of this PR