### PR TITLE
enhance: wordpress listing match only on GET

### DIFF
--- a/.appsec-tests/generic-wordpress-uploads-listing/generic-wordpress-uploads-listing.yaml
+++ b/.appsec-tests/generic-wordpress-uploads-listing/generic-wordpress-uploads-listing.yaml
@@ -37,6 +37,6 @@ http:
           - "status_code_3 == 403"
           - "status_code_4 == 403"
           - "status_code_5 == 404"
-          - "status_code_6 == 404"
-          - "status_code_7 == 404"
+          - "status_code_6 == 405"
+          - "status_code_7 == 405"
 

--- a/appsec-rules/crowdsecurity/generic-wordpress-uploads-listing.yaml
+++ b/appsec-rules/crowdsecurity/generic-wordpress-uploads-listing.yaml
@@ -14,21 +14,7 @@ rules:
       - urldecode
       match:
         type: regex
-        value: '^/wp-content/uploads/$'
-  - and:
-    - zones:
-      - METHOD
-      match:
-        type: equals
-        value: GET
-    - zones:
-      - URI
-      transform:
-      - lowercase
-      - urldecode
-      match:
-        type: regex
-        value: '^/wp-content/uploads/.*/$'
+        value: '^/wp-content/uploads/(.*/)?$'
     
 labels:
    type: exploit


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

fix #1697 

Outlook sends an options request to root of directory to see if it has permissions but ultimately the request will completed since the logo is inside the folder. Since this rule is primarily aimed at stopping listings we should only match `GET` requests since all other http methods either dont return data or dont modify anything.

<!--
Quick description of your changes
-->

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [x] I have tested my changes locally
 - [x] For new parsers or scenarios, tests have been added 
 - [x] I have run the hub linter and no issues were reported (see contributing guide)
 - [x] Automated tests are passing
 - [x] AI was used to generate any/all content of this PR