### PR TITLE
CVE-2025-40553

### DIFF
--- a/.appsec-tests/vpatch-CVE-2025-40553/CVE-2025-40553.yaml
+++ b/.appsec-tests/vpatch-CVE-2025-40553/CVE-2025-40553.yaml
@@ -1,0 +1,21 @@
+id: CVE-2025-40553
+info:
+  name: CVE-2025-40553
+  author: crowdsec
+  severity: info
+  description: CVE-2025-40553 testing
+  tags: appsec-testing
+http:
+  - method: POST
+    path:
+      - "{{BaseURL}}/helpdesk/WebObjects/Helpdesk.woa/ajax/9.7.43.0.0.0.4.3.7.0.7.1.1.1"
+    headers:
+      Content-Type: application/json
+    body: |
+      {"id":1,"method":"wopage.takeValueForKey","params":[{"javaClass":"org.apache.commons.collections.Transformer","object":"...gadget..."},"key"]}
+
+    cookie-reuse: true
+    matchers:
+      - type: status
+        status:
+          - 403

--- a/.appsec-tests/vpatch-CVE-2025-40553/config.yaml
+++ b/.appsec-tests/vpatch-CVE-2025-40553/config.yaml
@@ -1,0 +1,4 @@
+appsec-rules:
+  - ./appsec-rules/crowdsecurity/base-config.yaml
+  - ./appsec-rules/crowdsecurity/vpatch-CVE-2025-40553.yaml
+nuclei_template: CVE-2025-40553.yaml

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-40553.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-40553.yaml
@@ -1,0 +1,40 @@
+name: crowdsecurity/vpatch-CVE-2025-40553
+description: 'Detects SolarWinds Web Help Desk pre-auth RCE via jabsorb deserialization through AjaxProxy endpoint'
+rules:
+  - and:
+      - zones:
+          - URI
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '/helpdesk/webobjects/helpdesk.woa/ajax/'
+      - zones:
+          - BODY_ARGS
+        variables:
+          - json.method
+        transform:
+          - lowercase
+        match:
+          type: contains
+          value: 'takevalueforkey'
+      - zones:
+          - RAW_BODY
+        transform:
+          - lowercase
+        match:
+          type: contains
+          value: 'javaclass'
+
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: 'http:exploit'
+  label: 'SolarWinds Web Help Desk - RCE'
+  classification:
+    - cve.CVE-2025-40553
+    - attack.T1190
+    - cwe.CWE-502


### PR DESCRIPTION
Add virtual patch for CVE-2025-40553 — SolarWinds Web Help Desk Pre-Auth RCE via Jabsorb Deserialization
This PR adds a virtual patch rule and automated test for CVE-2025-40553, part of a pre-auth RCE chain (CVE-2025-40552/40553/40554) in SolarWinds Web Help Desk, disclosed by watchTowr on 2026-02-25.
Vulnerability summary: An unauthenticated attacker can POST a jabsorb deserialization payload to the AjaxProxy endpoint (/helpdesk/WebObjects/Helpdesk.woa/ajax/) using the wopage.takeValueForKey method with a javaClass gadget to achieve remote code execution.
Files added:

appsec-rules/crowdsecurity/vpatch-CVE-2025-40553.yaml — detection rule
.appsec-tests/vpatch-CVE-2025-40553/config.yaml — test configuration
.appsec-tests/vpatch-CVE-2025-40553/CVE-2025-40553.yaml — nuclei test template (validated, returns 403)

References:

https://labs.watchtowr.com/buy-a-help-desk-bundle-a-remote-access-solution-solarwinds-web-help-desk-pre-auth-rce-chain-s/
CWE-502 (Deserialization of Untrusted Data)