### PR TITLE
CVE-2025-40552

### DIFF
--- a/.appsec-tests/vpatch-CVE-2025-40552/CVE-2025-40552.yaml
+++ b/.appsec-tests/vpatch-CVE-2025-40552/CVE-2025-40552.yaml
@@ -1,0 +1,21 @@
+id: CVE-2025-40552
+info:
+  name: CVE-2025-40552
+  author: crowdsec
+  severity: info
+  description: CVE-2025-40552 testing
+  tags: appsec-testing
+http:
+  - raw:
+      - |
+        GET /helpdesk/WebObjects/Helpdesk.woa/wo/1.2 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        wopage=JavaSystemProperties
+
+    cookie-reuse: true
+    matchers:
+      - type: status
+        status:
+          - 403

--- a/.appsec-tests/vpatch-CVE-2025-40552/config.yaml
+++ b/.appsec-tests/vpatch-CVE-2025-40552/config.yaml
@@ -1,0 +1,4 @@
+appsec-rules:
+  - ./appsec-rules/crowdsecurity/base-config.yaml
+  - ./appsec-rules/crowdsecurity/vpatch-CVE-2025-40552.yaml
+nuclei_template: CVE-2025-40552.yaml

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-40552.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-40552.yaml
@@ -1,0 +1,34 @@
+name: crowdsecurity/vpatch-CVE-2025-40552
+description: 'Detects authentication bypass in SolarWinds Web Help Desk via WebObjects wopage parameter access to sensitive pages'
+rules:
+  - and:
+      - zones:
+          - URI
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '/helpdesk/webobjects/helpdesk.woa/wo/'
+      - zones:
+          - BODY_ARGS
+        variables:
+          - wopage
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: regex
+          value: '.+'
+
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: 'http:exploit'
+  label: 'SolarWinds Web Help Desk - Authentication Bypass'
+  classification:
+    - cve.CVE-2025-40552
+    - attack.T1190
+    - cwe.CWE-287


### PR DESCRIPTION
## Description
Adds a virtual patch for CVE-2025-40552, a pre-authentication bypass in 
SolarWinds Web Help Desk disclosed by watchTowr Labs (Feb 2026).

The vulnerability allows unauthenticated attackers to access sensitive 
WebObjects pages by sending a request to `/helpdesk/WebObjects/Helpdesk.woa/wo/` 
with any non-empty `wopage` body parameter.

This is the first stage of the full pre-auth RCE chain (CVE-2025-40552 → CVE-2025-40553).

## References
- https://labs.watchtowr.com/buy-a-help-desk-bundle-a-remote-access-solution-solarwinds-web-help-desk-pre-auth-rce-chain-s/
- https://www.cve.org/CVERecord?id=CVE-2025-40552