### PR TITLE
CVE-2023-29357

### DIFF
--- a/.appsec-tests/vpatch-CVE-2023-29357/CVE-2023-29357.yaml
+++ b/.appsec-tests/vpatch-CVE-2023-29357/CVE-2023-29357.yaml
@@ -1,0 +1,21 @@
+id: CVE-2023-29357
+info:
+  name: CVE-2023-29357
+  author: crowdsec
+  severity: info
+  description: CVE-2023-29357 testing
+  tags: appsec-testing
+http:
+  - raw:
+      - |
+        GET /_api/web/siteusers HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json
+        Authorization: Bearer eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDBAcmVhbG0iLCJpc3MiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAiLCJuYmYiOjE2OTU5ODc3MDMsImV4cCI6MjAxMTU0NzIyMywidmVyIjoiaGFzaGVkcHJvb2Z0b2tlbiIsIm5hbWVpZCI6IjAwMDAwMDAzLTAwMDAtMGZmMS1jZTAwLTAwMDAwMDAwMDAwMEByZWFsbSIsImVuZHBvaW50dXJsIjoicXFsQUptVHhwQjlBNjd4U3laayJ9.AAA
+        X-PROOF_TOKEN: eyJhbGciOiJub25lIn0.eyJ2ZXIiOiJoYXNoZWRwcm9vZnRva2VuIn0.AAA
+
+    cookie-reuse: true
+    matchers:
+      - type: status
+        status:
+          - 403

--- a/.appsec-tests/vpatch-CVE-2023-29357/config.yaml
+++ b/.appsec-tests/vpatch-CVE-2023-29357/config.yaml
@@ -1,0 +1,4 @@
+appsec-rules:
+  - ./appsec-rules/crowdsecurity/base-config.yaml
+  - ./appsec-rules/crowdsecurity/vpatch-CVE-2023-29357.yaml
+nuclei_template: CVE-2023-29357.yaml

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-29357.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-29357.yaml
@@ -1,0 +1,33 @@
+name: crowdsecurity/vpatch-CVE-2023-29357
+description: 'Detects Microsoft SharePoint authentication bypass via forged JWT tokens with "none" algorithm (CVE-2023-29357)'
+rules:
+  - and:
+      - zones:
+          - URI
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '/_api/'
+      - zones:
+          - HEADERS
+        variables:
+          - Authorization
+        transform:
+          - lowercase
+        match:
+          type: contains
+          value: 'hashedprooftoken'
+
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: 'http:exploit'
+  label: 'Microsoft SharePoint Server - Authentication Bypass'
+  classification:
+    - cve.CVE-2023-29357
+    - attack.T1190
+    - cwe.CWE-290

--- a/collections/crowdsecurity/appsec-virtual-patching.yaml
+++ b/collections/crowdsecurity/appsec-virtual-patching.yaml
@@ -42,6 +42,7 @@ appsec-rules:
 - crowdsecurity/vpatch-CVE-2023-46805
 - crowdsecurity/vpatch-CVE-2024-23897
 - crowdsecurity/vpatch-CVE-2023-22527
+- crowdsecurity/vpatch-CVE-2023-29357
 - crowdsecurity/vpatch-CVE-2024-5057
 - crowdsecurity/vpatch-CVE-2023-35078
 - crowdsecurity/vpatch-CVE-2023-35082


### PR DESCRIPTION
Add vpatch rule for CVE-2023-29357 — Microsoft SharePoint Authentication Bypass
Adds a virtual-patch AppSec rule and associated test assets for CVE-2023-29357, a critical (CVSS 9.8) authentication bypass in Microsoft SharePoint Server exploited by forging JWT tokens using the none signing algorithm to impersonate administrator sessions via the SharePoint REST API. This CVE is KEV-listed, actively used in ransomware campaigns, and chains with CVE-2023-24955 to achieve unauthenticated RCE. Over 150,000 SharePoint instances are exposed on the internet.
Detection logic: matches GET requests to /_api/ endpoints where the Authorization header contains the hashedprooftoken claim — a field injected by the exploit's forged JWT that does not appear in any legitimate SharePoint token.