### PR TITLE
Add vpatch rules for CVE-2026-20127 (Cisco SD-WAN vManage Pre-Auth RCE)

### DIFF
--- a/.appsec-tests/vpatch-CVE-2026-20127-dca-disclosure/CVE-2026-20127-dca-disclosure.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-20127-dca-disclosure/CVE-2026-20127-dca-disclosure.yaml
@@ -1,0 +1,16 @@
+id: CVE-2026-20127-dca-disclosure
+info:
+  name: CVE-2026-20127-dca-disclosure
+  author: crowdsec
+  severity: critical
+  description: Cisco SD-WAN vManage unauthenticated DCA credential disclosure testing
+  tags: appsec-testing
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}/reports/data/opt/data/containers/config/data-collection-agent/.dca"
+    cookie-reuse: true
+    matchers:
+    - type: status
+      status:
+       - 403

--- a/.appsec-tests/vpatch-CVE-2026-20127-dca-disclosure/config.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-20127-dca-disclosure/config.yaml
@@ -1,0 +1,4 @@
+appsec-rules:
+  - ./appsec-rules/crowdsecurity/base-config.yaml
+  - ./appsec-rules/crowdsecurity/vpatch-CVE-2026-20127-dca-disclosure.yaml
+nuclei_template: CVE-2026-20127-dca-disclosure.yaml

--- a/.appsec-tests/vpatch-CVE-2026-20127/CVE-2026-20127.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-20127/CVE-2026-20127.yaml
@@ -1,0 +1,25 @@
+id: CVE-2026-20127
+info:
+  name: CVE-2026-20127
+  author: crowdsec
+  severity: critical
+  description: Cisco SD-WAN vManage path traversal WAR upload RCE testing
+  tags: appsec-testing
+http:
+  - raw:
+      - |
+        POST /dataservice/smartLicensing/uploadAck HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+        ------WebKitFormBoundary7MA4YWxkTrZu0gW
+        Content-Disposition: form-data; name="file"; filename="../../../../../../../../../../../var/lib/wildfly/standalone/deployments/cmd.gz.war"
+        Content-Type: application/java-archive
+
+        PK
+        ------WebKitFormBoundary7MA4YWxkTrZu0gW--
+    cookie-reuse: true
+    matchers:
+    - type: status
+      status:
+       - 403

--- a/.appsec-tests/vpatch-CVE-2026-20127/config.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-20127/config.yaml
@@ -1,0 +1,4 @@
+appsec-rules:
+  - ./appsec-rules/crowdsecurity/base-config.yaml
+  - ./appsec-rules/crowdsecurity/vpatch-CVE-2026-20127.yaml
+nuclei_template: CVE-2026-20127.yaml

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127-dca-disclosure.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127-dca-disclosure.yaml
@@ -1,0 +1,25 @@
+name: crowdsecurity/vpatch-CVE-2026-20127-dca-disclosure
+description: 'Detects unauthenticated access to the DCA credential file in Cisco Catalyst SD-WAN Manager (CVE-2026-20127)'
+rules:
+  - and:
+      - zones:
+          - URI
+        transform:
+          - lowercase
+          - urldecode
+          - normalizepath
+        match:
+          type: contains
+          value: '/reports/data/opt/data/containers/config/data-collection-agent/.dca'
+
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: 'http:exploit'
+  label: 'Cisco SD-WAN vManage - Credentials Disclosure'
+  classification:
+    - cve.CVE-2026-20127
+    - attack.T1190
+    - cwe.CWE-552

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127.yaml
@@ -1,0 +1,33 @@
+name: crowdsecurity/vpatch-CVE-2026-20127
+description: 'Detects path traversal file upload exploitation in Cisco Catalyst SD-WAN Manager (CVE-2026-20127)'
+rules:
+  - and:
+      - zones:
+          - URI
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '/dataservice/smartlicensing/uploadack'
+      - zones:
+          - FILENAMES
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '..'
+
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: 'http:exploit'
+  label: 'Cisco SD-WAN vManage - RCE'
+  classification:
+    - cve.CVE-2026-20127
+    - attack.T1190
+    - cwe.CWE-22
+    - cwe.CWE-434

--- a/collections/crowdsecurity/appsec-virtual-patching.yaml
+++ b/collections/crowdsecurity/appsec-virtual-patching.yaml
@@ -168,6 +168,8 @@ appsec-rules:
 - crowdsecurity/vpatch-CVE-2025-66039
 - crowdsecurity/vpatch-CVE-2025-61678
 - crowdsecurity/vpatch-CVE-2025-4689
+- crowdsecurity/vpatch-CVE-2026-20127
+- crowdsecurity/vpatch-CVE-2026-20127-dca-disclosure
 author: crowdsecurity
 contexts:
 - crowdsecurity/appsec_base


### PR DESCRIPTION
Two rules covering the full exploit chain:
- vpatch-CVE-2026-20127: blocks path-traversal WAR upload to /dataservice/smartLicensing/uploadAck (step 3 - direct RCE trigger)
- vpatch-CVE-2026-20127-dca-disclosure: blocks unauthenticated access to the DCA credential file at /reports/data/.../data-collection-agent/.dca (step 1 - cred theft)

Both rules validated, linted, and live-tested via the WAF harness.
