### PR TITLE
fix(plex-allowlist): add missing HTTP status codes for streaming

### DIFF
--- a/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
+++ b/parsers/s02-enrich/crowdsecurity/plex-allowlist.yaml
@@ -4,11 +4,11 @@ filter: "evt.Meta.service == 'http' && evt.Meta.log_type in ['http_access-log', 
 whitelist:
   reason: "Plex Allowlist"
   expression:
-   - evt.Meta.http_status in ['200', '404'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/video/:/transcode/'
-   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/photo/:/transcode/'
-   - evt.Meta.http_status in ['200', '400'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/:/timeline'
-   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path matches '^/library/metadata/\\d+'
+   - evt.Meta.http_status in ['200', '206', '403', '404'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/video/:/transcode/'
+   - evt.Meta.http_status in ['200', '206'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/photo/:/transcode/'
+   - evt.Meta.http_status in ['200', '400', '403'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/:/timeline'
+   - evt.Meta.http_status in ['200', '403', '404'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/library/metadata/'
    - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path == '/status/sessions'
    - evt.Meta.http_status == '404' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/playQueues/'
    - evt.Meta.http_status == '403' && evt.Meta.http_verb == 'POST' && evt.Parsed.request == '/log' && evt.Parsed.http_args contains 'X-Plex-Product=Plex%20Cast&X-Plex-Version='
-   - evt.Meta.http_status == '200' && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/music/:/transcode/universal/session/'
+   - evt.Meta.http_status in ['200', '206'] && evt.Meta.http_verb == 'GET' && evt.Meta.http_path startsWith '/music/:/transcode/universal/session/'


### PR DESCRIPTION
## Problem

The `plex-allowlist` parser is missing several HTTP status codes that are produced by normal Plex client activity, causing legitimate Plex traffic to trigger scenarios like `http-crawl-non-statics` and `http-probing`.

### Missing status codes

**206 Partial Content** on `/video/:/transcode/` and `/music/:/transcode/universal/session/`
Video and audio streaming use HTTP range requests, which return 206, not 200. This is probably the most common false positive — any active stream will generate a flood of 206 responses that look like crawling to CrowdSec.

**403 Forbidden** on `/video/:/transcode/` and `/:/timeline`
When a Plex session's auth token expires mid-stream (e.g. the user pauses for a long time), the Plex client continues sending stop/session/timeline requests that return 403. These contain session IDs in the URL and are clearly normal client behavior.

**403 and 404** on `/library/metadata/`
Plex clients regularly fetch metadata that returns 403 (auth expired) or 404 (not found locally). Additionally, the existing `^\d+` regex doesn't match `plex://` GUID-style paths (e.g. `/library/metadata/plex%3A%2F%2Fmovie%2F5d776...`) that Plex uses for watch-together and discover features.

**206** on `/photo/:/transcode/`
Photo/thumbnail range requests can also return 206.

## Changes

- `/video/:/transcode/`: add `206`, `403`
- `/photo/:/transcode/`: add `206`
- `/:/timeline`: add `403`
- `/library/metadata/`: add `403`, `404`; replace `^\d+` regex with `startsWith` to cover `plex://` GUIDs
- `/music/:/transcode/universal/session/`: add `206`

🤖 Generated with [Claude Code](https://claude.com/claude-code)