### PR TITLE
Add Guezli/postfix-honeypot-users scenario

### DIFF
--- a/.tests/postfix-honeypot-users/config.yaml
+++ b/.tests/postfix-honeypot-users/config.yaml
@@ -1,0 +1,11 @@
+parsers:
+- crowdsecurity/postfix-logs
+- crowdsecurity/syslog-logs
+- crowdsecurity/dateparse-enrich
+scenarios:
+- scenarios/Guezli/postfix-honeypot-users.yaml
+postoverflows:
+- ""
+log_file: postfix-honeypot-users.log
+log_type: syslog
+ignore_parsers: true

--- a/.tests/postfix-honeypot-users/postfix-honeypot-users.log
+++ b/.tests/postfix-honeypot-users/postfix-honeypot-users.log
@@ -1,0 +1,4 @@
+May  6 09:25:41 mail postfix/smtps/smtpd[16997]: warning: unknown[203.0.113.10]: SASL LOGIN authentication failed: (reason unavailable), sasl_username=postmaster@example.org
+May  6 09:30:12 mail postfix/smtps/smtpd[17001]: warning: unknown[203.0.113.20]: SASL LOGIN authentication failed: (reason unavailable), sasl_username=admin@example.org
+May  6 09:35:55 mail postfix/smtps/smtpd[17005]: warning: unknown[203.0.113.30]: SASL LOGIN authentication failed: (reason unavailable), sasl_username=test@example.org
+May  6 09:40:22 mail postfix/smtps/smtpd[17009]: warning: unknown[203.0.113.40]: SASL LOGIN authentication failed: (reason unavailable), sasl_username=support@example.org

--- a/.tests/postfix-honeypot-users/scenario.assert
+++ b/.tests/postfix-honeypot-users/scenario.assert
@@ -1,0 +1,10 @@
+len(results) == 4
+"203.0.113.10" in results[0].Overflow.GetSources()
+"203.0.113.20" in results[1].Overflow.GetSources()
+"203.0.113.30" in results[2].Overflow.GetSources()
+"203.0.113.40" in results[3].Overflow.GetSources()
+results[0].Overflow.Alert.GetScenario() == "Guezli/postfix-honeypot-users"
+results[1].Overflow.Alert.GetScenario() == "Guezli/postfix-honeypot-users"
+results[2].Overflow.Alert.GetScenario() == "Guezli/postfix-honeypot-users"
+results[3].Overflow.Alert.GetScenario() == "Guezli/postfix-honeypot-users"
+results[0].Overflow.Alert.Remediation == true

--- a/scenarios/Guezli/postfix-honeypot-users.md
+++ b/scenarios/Guezli/postfix-honeypot-users.md
@@ -1,0 +1,58 @@
+## Postfix SASL honeypot-username instant ban
+
+Instant-bans IPs that try postfix SASL LOGIN with a honeypot username --
+well-known admin / role addresses (`postmaster@`, `admin@`, `info@`,
+`support@`, `office@`, `sales@`, `contact@`, `webmaster@`, `root@`,
+`noreply@`, `abuse@`, `hostmaster@`, `marketing@`, `mail@`, `news@`,
+`sysadmin@`, `administrator@`, `user@`, `service@`, `helpdesk@`) that
+should never be used as actual SMTP-AUTH login accounts.
+
+### Why this complements other postfix scenarios
+
+Distributed bruteforce bots iterate through a standard wordlist of role
+addresses, making only 1-2 attempts per IP to stay below per-IP rate
+thresholds. They escape:
+
+- `crowdsecurity/postfix-spam` (capacity 5 / leakspeed 10s -- 6+ fast fails)
+- `Guezli/postfix-sasl-bf` (capacity 2 / leakspeed 7200s -- 3+ fails per IP)
+
+Since no legitimate mail setup logs in via SMTP with `postmaster@` or
+`admin@`, a single attempt with such a username is high-confidence
+attacker signal -- ban immediately (`type: trigger`, `confidence: 5`).
+
+### Requirements
+
+- `crowdsecurity/postfix-logs` parser (part of the `crowdsecurity/postfix`
+  collection)
+
+### Acquisition example
+
+For Mailcow's postfix container:
+
+```yaml
+source: docker
+container_name:
+  - mailcowdockerized-postfix-mailcow-1
+labels:
+  type: syslog
+```
+
+For a standalone postfix with file-based syslog:
+
+```yaml
+filenames:
+  - /var/log/mail.log
+labels:
+  type: syslog
+```
+
+### Notes
+
+- The `behavior` label is `pop3/imap:bruteforce` because the hub taxonomy
+  has no dedicated `smtp:bruteforce` entry. Same convention as the
+  companion scenario `Guezli/postfix-sasl-bf`.
+- Customize the honeypot username list to your environment: if you
+  legitimately accept SASL-AUTH for any of the addresses above, fork the
+  scenario and remove the matching entries from the filter regex.
+- Tuning notes, installer and detailed background:
+  https://github.com/Guezli/postfix-honeypot-users

--- a/scenarios/Guezli/postfix-honeypot-users.yaml
+++ b/scenarios/Guezli/postfix-honeypot-users.yaml
@@ -1,0 +1,43 @@
+# Trigger an instant ban when an IP attempts SASL LOGIN against postfix
+# using one of the well-known "honeypot" usernames -- addresses that should
+# never be used as actual SMTP login accounts (postmaster@, admin@, info@,
+# support@, ...).
+#
+# Background: distributed bruteforce bots iterate through a standard
+# wordlist of admin/role addresses trying just 1-2 attempts per IP to stay
+# below per-IP thresholds. Since nobody on a sane mail setup uses those
+# addresses as actual SMTP-AUTH logins, any attempt is a clear attacker
+# signal -- ban on first hit.
+#
+# Requires the official `crowdsecurity/postfix-logs` parser, which extracts
+# SASL fields and source_ip from the postfix log line.
+#
+# Customize the username list to match your environment. If you
+# legitimately use any of these as SMTP login (rare), remove it.
+
+type: trigger
+name: Guezli/postfix-honeypot-users
+description: "Instant-ban IPs hitting postfix SASL LOGIN with honeypot usernames"
+filter: |
+  evt.Meta.log_type == 'postfix'
+  && evt.Parsed.message contains 'SASL'
+  && evt.Parsed.message contains 'authentication failed'
+  && evt.Parsed.message matches '(?i)sasl_username=(postmaster|admin|info|test|support|office|sales|contact|webmaster|root|noreply|abuse|hostmaster|marketing|mail|news|sysadmin|administrator|user|service|helpdesk)@'
+groupby: evt.Meta.source_ip
+# trigger = first hit overflows; blackhole prevents bucket spam from the
+# same IP within the next 24h
+blackhole: 24h
+labels:
+  service: postfix
+  remediation: true
+  confidence: 5
+  spoofable: 0
+  classification:
+    - attack.T1110
+    - attack.T1078
+  behavior: "pop3/imap:bruteforce"
+  label: "Postfix Honeypot Username"
+references:
+  - https://www.postfix.org/SASL_README.html
+  - https://attack.mitre.org/techniques/T1110/
+  - https://attack.mitre.org/techniques/T1078/


### PR DESCRIPTION
## Description

Adds a new scenario `Guezli/postfix-honeypot-users` that instant-bans IPs
attempting postfix SASL LOGIN with a well-known role/admin username
(`postmaster@`, `admin@`, `info@`, `support@`, `office@`, `sales@`,
`contact@`, `webmaster@`, `root@`, `noreply@`, `abuse@`, `hostmaster@`,
`marketing@`, `mail@`, `news@`, `sysadmin@`, `administrator@`, `user@`,
`service@`, `helpdesk@`).

These addresses should never be used as actual SMTP-AUTH login accounts,
so a single attempt is high-confidence attacker signal (`type: trigger`,
`confidence: 5`).

Complements:

- `crowdsecurity/postfix-spam` (capacity 5 / leakspeed 10s — fast-pattern)
- `Guezli/postfix-sasl-bf` (capacity 2 / leakspeed 7200s — slow-pattern)

by catching distributed wordlist attackers that make only 1-2 attempts per
IP and slip below both per-IP thresholds.

## Checklist

- [x] Scenario YAML with required labels (classification, spoofable, confidence, behavior, label, service, remediation)
- [x] Hub-rendered `.md` documentation with acquisition example
- [x] hubtest under `.tests/postfix-honeypot-users/` passing locally (`cscli hubtest run postfix-honeypot-users --clean` -> all tests passed)
- [x] `hublint check` clean (0 warnings, 0 errors)
- [x] Uses existing `crowdsecurity/postfix-logs` parser, no new parser needed
- [x] Test fixture uses RFC 5737 IPs (`203.0.113.0/24`)

## AI assistance

- [x] AI was used to generate any/all content of this PR

Claude Code was used to port the scenario from my personal repo
(https://github.com/Guezli/postfix-honeypot-users) into Hub format, generate
the hubtest assertions, and structure the documentation. The detection
logic, honeypot wordlist tuning, and field-of-use research are my own work;
I can explain every part of the contribution.
