### PR TITLE
feat(scenario): add JMAP HTTP brute-force scenario for boris22100

### DIFF
--- a/scenarios/boris22100/jmap-http-bf.yaml
+++ b/scenarios/boris22100/jmap-http-bf.yaml
@@ -1,0 +1,13 @@
+type: leaky
+name: boris22100/jmap-http-bf
+description: "Detect JMAP brute force attacks on HTTP/HTTPS endpoints"
+filter: "evt.Meta.log_type == 'http_access-log' && evt.Parsed.request matches '^/jmap' && int(evt.Parsed.status) in [401, 403]"
+groupby: "evt.Meta.source_ip"
+capacity: 5
+leakspeed: "30s"
+blackhole: 5m
+labels:
+  service: http
+  remediation: ban
+  taxonomy:
+    attack: brute-force


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

This PR introduces a new HTTP scenario to detect brute-force attacks targeting JMAP (JSON Meta Application Protocol - RFC 8620) endpoints. 

JMAP relies fully on HTTP/HTTPS. This scenario monitors HTTP access logs (from reverse proxies like Traefik, Nginx, Caddy, etc.) and triggers a ban if a source IP accumulates multiple `401 Unauthorized` or `403 Forbidden` responses on the `/jmap` path within a short window.

This is particularly useful for protecting modern mail servers like Stalwart or Apache James that implement the JMAP specification.

## Checklist
- [x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
- [x] I have tested my changes locally
- [ ] For new parsers or scenarios, tests have been added 
- [ ] I have run the hub linter and no issues were reported (see contributing guide)
- [ ] Automated tests are passing
- [ ] AI was used to generate any/all content of this PR