### PR TITLE
Update adguardhome-logs.yaml for parse new logs

### DIFF
--- a/parsers/s01-parse/LePresidente/adguardhome-logs.yaml
+++ b/parsers/s01-parse/LePresidente/adguardhome-logs.yaml
@@ -5,6 +5,12 @@ description: "Parse adguardhome logs"
 filter: "evt.Parsed.program == 'adguardhome'"
 nodes:
   - grok:
+      pattern: '%{YEAR}/%{MONTHNUM}/%{MONTHDAY} %{TIME:time}\.%{GREEDYDATA:milliseconds} \[%{LOGLEVEL:level}\] %{WORD:service}: http error host=%{HOSTNAME:host} method=%{WORD:method} url=%{URIPATH:url} status=%{NUMBER:status} ip=%{IP:source_ip} err="%{GREEDYDATA:error_message}"'
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: adguardhome_failed_auth
+  - grok:
       pattern: '%{DATE_X:date} %{TIME:time}.* POST %{HOSTNAME} /control/login: from ip %{IP:source_ip}: invalid username or password$'
       apply_on: message
       statics:


### PR DESCRIPTION
<!--
Thanks for contributing to the CrowdSec Hub !
To help us merge your PR as quick as possible, please fill out all the following fields.
-->
## Description

The log format change to : 

2026/06/03 21:13:32.653418 [error] webapi: http error host=dns.mondomaine.com method=POST url=/control/login status=403 ip=192.168.1.1 err="invalid username or password"

With this change the failed login is parsed

╭──────────────────────────────────────────────────────────╮
│ (Parser) LePresidente/adguardhome-logs                   │
├───────────────────────────────┬──────┬────────┬──────────┤
│ Parsers                       │ Hits │ Parsed │ Unparsed │
├───────────────────────────────┼──────┼────────┼──────────┤
│ file:/var/log/AdGuardHome.log │ 10   │ 8      │ 2        │

## Checklist
<!--

Add a x inside the [] to tick an item if it applies.

For AI use: we do not prevent you from using AI to help you create new hub items, but you must understand and be able to explain *yourself* what was generated.
-->
 - [ x] I have read the [contributing guide](https://docs.crowdsec.net/docs/next/contributing/contributing_hub)
 - [ x] I have tested my changes locally
 - [ ] For new parsers or scenarios, tests have been added 
 - [ x] I have run the hub linter and no issues were reported (see contributing guide)
 - [ ] Automated tests are passing
 - [x ] AI was used to generate any/all content of this PR