### PR TITLE
Guezli/postfix-honeypot-users: align doc wording with filter scope

### DIFF
--- a/scenarios/Guezli/postfix-honeypot-users.md
+++ b/scenarios/Guezli/postfix-honeypot-users.md
@@ -1,11 +1,15 @@
 ## Postfix SASL honeypot-username instant ban
 
-Instant-bans IPs that try postfix SASL LOGIN with a honeypot username --
-well-known admin / role addresses (`postmaster@`, `admin@`, `info@`,
-`support@`, `office@`, `sales@`, `contact@`, `webmaster@`, `root@`,
-`noreply@`, `abuse@`, `hostmaster@`, `marketing@`, `mail@`, `news@`,
-`sysadmin@`, `administrator@`, `user@`, `service@`, `helpdesk@`) that
-should never be used as actual SMTP-AUTH login accounts.
+Instant-bans IPs that try postfix SASL authentication with a honeypot
+username -- well-known admin / role addresses (`postmaster@`, `admin@`,
+`info@`, `test@`, `support@`, `office@`, `sales@`, `contact@`,
+`webmaster@`, `root@`, `noreply@`, `abuse@`, `hostmaster@`, `marketing@`,
+`mail@`, `news@`, `sysadmin@`, `administrator@`, `user@`, `service@`,
+`helpdesk@`) that should never be used as actual SMTP-AUTH login accounts.
+
+The filter matches any SASL mechanism (LOGIN, PLAIN, CRAM-MD5, DIGEST-MD5)
+parsed by `crowdsecurity/postfix-logs` -- attackers using PLAIN against
+role-only addresses are just as much a clear signal as LOGIN.
 
 ### Why this complements other postfix scenarios
 

--- a/scenarios/Guezli/postfix-honeypot-users.yaml
+++ b/scenarios/Guezli/postfix-honeypot-users.yaml
@@ -1,7 +1,12 @@
-# Trigger an instant ban when an IP attempts SASL LOGIN against postfix
+# Trigger an instant ban when an IP attempts postfix SASL authentication
 # using one of the well-known "honeypot" usernames -- addresses that should
 # never be used as actual SMTP login accounts (postmaster@, admin@, info@,
-# support@, ...).
+# test@, support@, ...).
+#
+# The filter is intentionally not restricted to "SASL LOGIN" — the official
+# `crowdsecurity/postfix-logs` parser flags all SASL mechanism failures
+# (LOGIN, PLAIN, CRAM-MD5, DIGEST-MD5), and an attacker using PLAIN against
+# `postmaster@` is just as much a clear signal as LOGIN.
 #
 # Background: distributed bruteforce bots iterate through a standard
 # wordlist of admin/role addresses trying just 1-2 attempts per IP to stay
@@ -17,7 +22,7 @@
 
 type: trigger
 name: Guezli/postfix-honeypot-users
-description: "Instant-ban IPs hitting postfix SASL LOGIN with honeypot usernames"
+description: "Instant-ban IPs hitting postfix SASL authentication with honeypot usernames"
 filter: |
   evt.Meta.log_type == 'postfix'
   && evt.Parsed.message contains 'SASL'


### PR DESCRIPTION
## Description

Follow-up to #1806 addressing the two Copilot review comments that
remained unresolved at merge time:

- The description, top-of-file comment block and rendered `.md` all
  said "SASL LOGIN", but the filter only checks for `SASL` + `authentication failed`
  and therefore matches every SASL mechanism the upstream
  `crowdsecurity/postfix-logs` parser flags (LOGIN, PLAIN, CRAM-MD5, DIGEST-MD5).
  Wording is now "SASL authentication" so docs and filter agree.
  The broader scope is intentional -- catching a PLAIN attempt against
  `postmaster@` is just as much a clear attacker signal as LOGIN.
- The `.md` username list was missing `test@`, which the scenario regex
  includes. Added it.

## Functional impact

None. Pure doc/wording alignment. `cscli hubtest run postfix-honeypot-users --clean`
stays green locally, `hublint check` clean.

## AI assistance

- [x] AI was used to generate any/all content of this PR

Claude Code generated the wording-alignment edits based on the Copilot
review comments left on #1806.
