### PR TITLE
do not make decision required to do RDNS enrichment

### DIFF
--- a/postoverflows/s00-enrich/crowdsecurity/rdns.yaml
+++ b/postoverflows/s00-enrich/crowdsecurity/rdns.yaml
@@ -1,5 +1,5 @@
 onsuccess: next_stage
-filter: "evt.Overflow.Alert.Remediation == true && evt.Overflow.Alert.GetScope() == 'Ip'"
+filter: "evt.Overflow.Alert.GetScope() == 'Ip'"
 name: crowdsecurity/rdns
 description: "Lookup the DNS associated to the source IP only for overflows"
 statics:


### PR DESCRIPTION
 - fixed a bug where RDNS based postoverflow whitelists wouldn't work because RDNS enrichment only happens **if** there is a decision in the alert.