### PR TITLE
fix(ban-defcon-drop_range): skip overflow events with empty Source.Range

### DIFF
--- a/scenarios/crowdsecurity/ban-defcon-drop_range.yaml
+++ b/scenarios/crowdsecurity/ban-defcon-drop_range.yaml
@@ -4,7 +4,7 @@ type: leaky
 name: crowdsecurity/ban-defcon-drop_range
 description: "Ban a range if more than 5 ips from it are banned at a time"
 #it's an overflow from a scenario that triggered a remediation ;)
-filter: "evt.GetType() == 'overflow' && evt.Overflow.Alert.Remediation == true"
+filter: "evt.GetType() == 'overflow' && evt.Overflow.Alert.Remediation == true && evt.Overflow.Alert.Source.Range != nil && evt.Overflow.Alert.Source.Range != ''"
 groupby: "evt.Overflow.Alert.Source.Range"
 distinct: "evt.Overflow.Alert.Source.IP"
 capacity: 5


### PR DESCRIPTION
## Summary
- `crowdsecurity/ban-defcon-drop_range` groups overflow events by `evt.Overflow.Alert.Source.Range`.
- When ASN/range enrichment fails for a given source IP, `Source.Range` is empty, so the bucket groups under key `""`.
- When that bucket overflows, it tries to create a decision with scope `Range` and value `''`, which the DB layer rejects: `invalid addr/range '': invalid ip address ''`. The alert is dropped and an error is logged.
- Adds a filter guard (`Source.Range != nil && Source.Range != ''`) so these events are skipped instead of producing an invalid decision, and no error is logged.

## Observed
Recurring on a production instance (crowdsec v1.7.8, docker) roughly every 10-60 minutes:
```
{"level":"error","msg":"error while checking allowlist: invalid ip address ''"}
{"level":"error","module":"db","msg":"invalid addr/range '': invalid ip address ''"}
{"level":"warning","module":"db","msg":"discarded 1 decisions for <uuid>"}
{"level":"warning","module":"db","msg":"dropping alert <uuid>: all decisions invalid"}
```

## Test plan
- [x] Ran `uv run mkindex` to regenerate `.index.json` (version bumped 0.2 -> 0.3)
- [x] Deployed patched scenario locally as a local override, confirmed no more `invalid addr/range` errors over 30s+ after restart
- [ ] Would appreciate a maintainer sanity check on whether `Source.Range` can legitimately be nil vs empty string in the expr-lang context, to make sure the guard covers both cases