### PR TITLE
vpatch for CVE-2026-61511 (vBulletin runMaths pre-auth RCE)

### DIFF
--- a/.appsec-tests/vpatch-CVE-2026-61511/CVE-2026-61511.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-61511/CVE-2026-61511.yaml
@@ -1,0 +1,20 @@
+id: CVE-2026-61511
+info:
+  name: CVE-2026-61511
+  author: crowdsec
+  severity: info
+  description: CVE-2026-61511 testing - vBulletin runMaths pre-auth RCE
+  tags: appsec-testing
+http:
+  - raw:
+      - |
+        POST /ajax/render/pagenav HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/x-www-form-urlencoded
+
+        routestring=ajax/render/pagenav&pagenav[pagenumber]=(0^0).(0^0)&pagenav[currentpage]=1
+    cookie-reuse: true
+    matchers:
+    - type: status
+      status:
+       - 403

--- a/.appsec-tests/vpatch-CVE-2026-61511/CVE-2026-61511.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-61511/CVE-2026-61511.yaml
@@ -8,7 +8,7 @@ info:
 http:
   - raw:
       - |
-        POST /ajax/render/pagenav HTTP/1.1
+        POST /index.php HTTP/1.1
         Host: {{Hostname}}
         Content-Type: application/x-www-form-urlencoded
 

--- a/.appsec-tests/vpatch-CVE-2026-61511/config.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-61511/config.yaml
@@ -1,0 +1,4 @@
+appsec-rules:
+- ./appsec-rules/crowdsecurity/base-config.yaml
+- ./appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
+nuclei_template: CVE-2026-61511.yaml

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
@@ -1,0 +1,34 @@
+name: crowdsecurity/vpatch-CVE-2026-61511
+description: 'Detects vBulletin runtime template runMaths pre-auth RCE via crafted pagenav[pagenumber] on /ajax/render/pagenav.'
+rules:
+  - and:
+      - zones:
+          - URI
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '/ajax/render/pagenav'
+      - zones:
+          - BODY_ARGS
+        variables:
+          - /pagenav\[pagenumber\]/
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '('
+
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: 'http:exploit'
+  label: 'vBulletin - RCE'
+  classification:
+    - cve.CVE-2026-61511
+    - attack.T1190
+    - cwe.CWE-95

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
@@ -15,7 +15,7 @@ rules:
       - zones:
           - BODY_ARGS
         variables:
-          - /pagenav\[pagenumber\]/
+          - pagenav\[pagenumber\]
         transform:
           - lowercase
           - urldecode

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
@@ -1,7 +1,17 @@
 name: crowdsecurity/vpatch-CVE-2026-61511
-description: 'Detects vBulletin runtime template runMaths pre-auth RCE via crafted pagenav[pagenumber] parameter'
+description: 'Detects vBulletin runtime template runMaths pre-auth RCE via crafted pagenav[pagenumber] routed through routestring=ajax/render/pagenav.'
 rules:
   - and:
+      - zones:
+          - BODY_ARGS
+        variables:
+          - routestring
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: 'ajax/render/pagenav'
       - zones:
           - BODY_ARGS
         variables:

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
@@ -1,15 +1,7 @@
 name: crowdsecurity/vpatch-CVE-2026-61511
-description: 'Detects vBulletin runtime template runMaths pre-auth RCE via crafted pagenav[pagenumber] on /ajax/render/pagenav.'
+description: 'Detects vBulletin runtime template runMaths pre-auth RCE via crafted pagenav[pagenumber] parameter'
 rules:
   - and:
-      - zones:
-          - URI
-        transform:
-          - lowercase
-          - urldecode
-        match:
-          type: contains
-          value: '/ajax/render/pagenav'
       - zones:
           - BODY_ARGS
         variables:

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
@@ -15,7 +15,7 @@ rules:
       - zones:
           - BODY_ARGS
         variables:
-          - pagenav\[pagenumber\]
+          - pagenav[pagenumber]
         transform:
           - lowercase
           - urldecode

--- a/collections/crowdsecurity/appsec-virtual-patching.yaml
+++ b/collections/crowdsecurity/appsec-virtual-patching.yaml
@@ -194,6 +194,7 @@ appsec-rules:
 - crowdsecurity/vpatch-CVE-2026-26980
 - crowdsecurity/vpatch-CVE-2026-46725
 - crowdsecurity/vpatch-CVE-2026-63030
+- crowdsecurity/vpatch-CVE-2026-61511
 author: crowdsecurity
 contexts:
 - crowdsecurity/appsec_base


### PR DESCRIPTION

Detects exploitation of vB5_Template_Runtime::runMaths() via a crafted pagenav[pagenumber] on POST /ajax/render/pagenav. Matches the mandatory '(' metacharacter (function call required for eval-based RCE) scoped to the vulnerable URI and parameter.
