### PR TITLE
fix(appsec): urldecode before lowercase on raw zones

### DIFF
--- a/.appsec-tests/vpatch-CVE-2024-8181/CVE-2024-8181.yaml
+++ b/.appsec-tests/vpatch-CVE-2024-8181/CVE-2024-8181.yaml
@@ -13,8 +13,15 @@ http:
         Host: {{Hostname}}
         Accept: application/json, text/plain, */*
         Referer: {{RootURL}}/document-stores
+      - |
+        GET /%41pi/v1/apikey?/api/v1/ping HTTP/1.1
+        Host: {{Hostname}}
+        Accept: application/json, text/plain, */*
+        Referer: {{RootURL}}/document-stores
     cookie-reuse: true
     matchers:
-    - type: status
-      status:
-       - 403
+    - type: dsl
+      condition: and
+      dsl:
+        - 'status_code_1 == 403'
+        - 'status_code_2 == 403'

--- a/.appsec-tests/vpatch-CVE-2026-41940/CVE-2026-41940.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-41940/CVE-2026-41940.yaml
@@ -22,6 +22,11 @@ http:
         Host: {{Hostname}}
         Cookie: whostmgrsession=%3aQSJN_sFdKZtCi2o_%2Ctoto
         Authorization: Basic cm9vdDp4DQpoYXNyb290PTENCnRmYV92ZXJpZmllZD0xDQp1c2VyPXJvb3Q=
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: whostmgrsession=%3a%51SJN_sFdKZtCi2o_
+        Authorization: Basic cm9vdDp4DQpoYXNyb290PTENCnRmYV92ZXJpZmllZD0xDQp1c2VyPXJvb3Q=
     cookie-reuse: true
     matchers:
     - type: dsl
@@ -30,3 +35,4 @@ http:
         - 'status_code_1 == 403'
         - 'status_code_2 == 403'
         - 'status_code_3 == 200'
+        - 'status_code_4 == 403'

--- a/.appsec-tests/vpatch-CVE-2026-46725/CVE-2026-46725.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-46725/CVE-2026-46725.yaml
@@ -12,8 +12,15 @@ http:
         Host: {{Hostname}}
         Cookie: T3_ceselector_1=O%3A28%3A%22Monolog%5CHandler%5CGroupHandler%22%3A1%3A%7B%7D
 
+      - |
+        GET / HTTP/1.1
+        Host: {{Hostname}}
+        Cookie: T3_ceselector_1=%4F%3A28%3A%22Monolog%5CHandler%5CGroupHandler%22%3A1%3A%7B%7D
+
     cookie-reuse: true
     matchers:
-      - type: status
-        status:
-          - 403
+      - type: dsl
+        condition: and
+        dsl:
+          - 'status_code_1 == 403'
+          - 'status_code_2 == 403'

--- a/.appsec-tests/vpatch-CVE-2026-63030/CVE-2026-63030.yaml
+++ b/.appsec-tests/vpatch-CVE-2026-63030/CVE-2026-63030.yaml
@@ -33,8 +33,16 @@ http:
 
         {"requests":[{"method":"POST","path":"http://:"},{"method":"POST","path":"/wp/v2/posts","body":{"requests":[{"method":"GET","path":"http://:"},{"method":"GET","path":"/wp/v2/categories?author_exclude=SELECT+IF%28%281%3D1%29%2CSLEEP%287%29%2C0%29"},{"method":"GET","path":"/wp/v2/posts"}]}},{"method":"POST","path":"/batch/v1"}]}
 
-    matchers-condition: and
+      - |
+        POST /?rest_route=/%42atch/v1 HTTP/1.1
+        Host: {{Hostname}}
+        Content-Type: application/json
+
+        {"requests":[{"method":"POST","path":"http://:"},{"method":"POST","path":"/wp/v2/posts","body":{"requests":[{"method":"GET","path":"http://:"},{"method":"GET","path":"/wp/v2/categories?author_exclude=SELECT+IF%28%281%3D1%29%2CSLEEP%287%29%2C0%29"},{"method":"GET","path":"/wp/v2/posts"}]}},{"method":"POST","path":"/batch/v1"}]}
+
     matchers:
-      - type: status
-        status:
-          - 403
+      - type: dsl
+        condition: and
+        dsl:
+          - 'status_code_1 == 403'
+          - 'status_code_2 == 403'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2019-5418.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2019-5418.yaml
@@ -7,8 +7,8 @@ rules:
     variables:
       - accept
     transform:
-      - lowercase
       - urldecode
+      - lowercase
     match:
       type: contains
       value: '../'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-8181.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-8181.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI_FULL
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/api/v1/apikey?/api/v1/ping'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-41940.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-41940.yaml
@@ -7,8 +7,8 @@ rules:
         variables:
           - whostmgrsession
         transform:
-          - lowercase
           - urldecode
+          - lowercase
           - trim
         match:
           type: regex

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-46725.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-46725.yaml
@@ -6,8 +6,8 @@ rules:
       variables:
         - '/t3_ceselector_.*/'
       transform:
-        - lowercase
         - urldecode
+        - lowercase
       match:
         type: regex
         value: '[oc]:\d+:'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-63030.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-63030.yaml
@@ -5,7 +5,7 @@ rules:
   - or:
     - and:
         - zones: [URI_FULL]
-          transform: [lowercase, urldecode]
+          transform: [urldecode, lowercase]
           match: {type: contains, value: 'batch/v1'}
         - zones: [RAW_BODY]
           transform: [lowercase]
@@ -13,10 +13,10 @@ rules:
     # Node 2 - author_exclude/author__not_in SQLi
     - and:
         - zones: [URI_FULL]
-          transform: [lowercase, urldecode]
+          transform: [urldecode, lowercase]
           match: {type: contains, value: 'batch/v1'}
         - zones: [RAW_BODY]
-          transform: [lowercase, urldecode]
+          transform: [urldecode, lowercase]
           match: {type: regex, value: 'author_(?:exclude|_not_in)\s*=\s*[^0-9]+'}
 labels:
   type: exploit


### PR DESCRIPTION
`transform: [lowercase, urldecode]` lowercases before decoding, so a percent-escape survives the fold and decodes to an uppercase letter afterwards, which the lowercase match then misses. Swapped to `[urldecode, lowercase]`.

These 5 rules use zones Coraza does not pre-decode (`COOKIES`, `HEADERS`, `URI_FULL`, `RAW_BODY`), so a single percent-encoding is enough to evade them. Checked against the Coraza engine: for CVE-2026-46725, `Cookie: t3_ceselector_x=%4F:8:"stdClass"` does not match today and matches after the swap. PHP urldecodes `$_COOKIE`, so that payload still reaches `unserialize()`.

Same root cause as crowdsecurity/alert-context-rules#1107. A second PR covers the remaining 82 files, which use pre-decoded zones and need double encoding to bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kCVups4eddfjUonQomPcs