### PR TITLE
fix(appsec): urldecode before lowercase on pre-decoded zones

### DIFF
--- a/.appsec-tests/vpatch-CVE-2025-57819/CVE-2025-57819.yaml
+++ b/.appsec-tests/vpatch-CVE-2025-57819/CVE-2025-57819.yaml
@@ -10,8 +10,11 @@ http:
   - method: GET
     path:
       - "{{BaseURL}}/admin/ajax.php?module=FreePBX%5Cmodules%5Cendpoint%5Cajax&command=model&template=x&model=model&brand=x'%20AND%20EXTRACTVALUE(1,CONCAT('~USER:',(SELECT%20USER()),'~'))%20--%20"
+      - "{{BaseURL}}/admin/ajax.php?module=%2546ree%2550BX%255Cmodules%255Cendpoint%255Cajax&command=model&template=x&model=model&brand=x'%20AND%20EXTRACTVALUE(1,CONCAT('~USER:',(SELECT%20USER()),'~'))%20--%20"
     cookie-reuse: true
     matchers:
-    - type: status
-      status:
-       - 403
+    - type: dsl
+      condition: and
+      dsl:
+        - 'status_code_1 == 403'
+        - 'status_code_2 == 403'

--- a/appsec-rules/crowdsecurity/generic-wordpress-uploads-listing.yaml
+++ b/appsec-rules/crowdsecurity/generic-wordpress-uploads-listing.yaml
@@ -10,8 +10,8 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: regex
         value: '^/wp-content/uploads/(.*/)?$'

--- a/appsec-rules/crowdsecurity/generic-wordpress-uploads-php.yaml
+++ b/appsec-rules/crowdsecurity/generic-wordpress-uploads-php.yaml
@@ -5,8 +5,8 @@ rules:
     - zones: 
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: regex
         value: '/wp-content/uploads/.*\.(h?ph(p|tm?l?|ar)|module|shtml)'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2002-1131.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2002-1131.yaml
@@ -6,16 +6,16 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /src/addressbook.php
       - zones:
           - ARGS_NAMES
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: <
@@ -23,8 +23,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /src/options.php
@@ -33,8 +33,8 @@ rules:
         variables:
           - optpage
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: <
@@ -42,8 +42,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /src/search.php
@@ -53,8 +53,8 @@ rules:
           - mailbox
           - where
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: <
@@ -62,8 +62,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /src/help.php
@@ -72,8 +72,8 @@ rules:
         variables:
           - chapter
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: <

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2007-0885.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2007-0885.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /jira/secure/browseproject.jspa
@@ -16,8 +16,8 @@ rules:
         variables:
           - id
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: <

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2014-5181.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2014-5181.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /wp-content/plugins/lastfm-rotation/lastfm-proxy.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - snode
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '../'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2018-11511.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2018-11511.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - album_id
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '[^0-9]+'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2018-13317.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2018-13317.yaml
@@ -5,8 +5,8 @@ rules:
   - zones:
       - URI
     transform:
-      - lowercase
       - urldecode
+      - lowercase
     match:
       type: equals
       value: /password.htm

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2019-9762.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2019-9762.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - id
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: "[^a-z0-9]"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2020-10987.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2020-10987.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - deviceName
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '[^a-z0-9]'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2020-13640.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2020-13640.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - order
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '('

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2020-25078.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2020-25078.yaml
@@ -6,8 +6,8 @@ rules:
     - zones:
         - URI
       transform:
-        - lowercase
         - urldecode
+        - lowercase
       match:
         type: contains
         value: '/config/getuser'
@@ -16,8 +16,8 @@ rules:
       variables:
         - 'index'
       transform:
-        - lowercase
         - urldecode
+        - lowercase
       match:
         type: regex
         value: '^[0-9]+$'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2020-37123.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2020-37123.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/ping.php'
@@ -15,8 +15,8 @@ rules:
         variables:
           - ping
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '[;|&`$]'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2020-5902.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2020-5902.yaml
@@ -11,8 +11,8 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: /tmui/login.jsp/..;/tmui/

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2020-8656.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2020-8656.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - username
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "'"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2021-26072.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2021-26072.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /rest/sharelinks/1.0/link
@@ -16,8 +16,8 @@ rules:
         variables:
           - url
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'http'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2021-26294.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2021-26294.yaml
@@ -6,16 +6,16 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /dav/server.php/files/personal/
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '..'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2021-32478.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2021-32478.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - redirect_uri
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'javascript:'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2021-34427.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2021-34427.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/document'
@@ -16,8 +16,8 @@ rules:
         variables:
           - __document
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '.jsp/.'
@@ -26,8 +26,8 @@ rules:
         variables:
           - sample
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '<%'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2022-25322.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2022-25322.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - o33
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "'"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2022-26134.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2022-26134.yaml
@@ -11,24 +11,24 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: startsWith
         value: '/${'
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: "@java.lang.runtime"
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: "@org.apache.commons.io.ioutils"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2022-31499.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2022-31499.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - readerno
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '`'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2022-3236.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2022-3236.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '/(userportal|webconsole)/controller'
@@ -15,8 +15,8 @@ rules:
         variables:
           - json
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '`|\$\('

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2022-3254.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2022-3254.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /wp-admin/admin-ajax.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - parent
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: "[^a-z0-9]"
@@ -26,8 +26,8 @@ rules:
         variables:
           - action
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: equals
           value: awpcp-get-regions-options

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2022-38627.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2022-38627.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/badging/badge_template_print.php'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-0297.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-0297.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /flash/addcrypted2
@@ -16,8 +16,8 @@ rules:
         variables:
           - jk
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: pyimport

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-23063.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-23063.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - path
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '^(/|\.\./)'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-24000.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-24000.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /wp-json/wp/v2/gamipress-logs
@@ -16,8 +16,8 @@ rules:
         variables:
           - trigger_type[]
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: "[^a-z0-9_-]"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-3169.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-3169.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - compiled_css
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '<'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-3197.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-3197.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /wp-json/api/flutter_multi_vendor/product-categories
@@ -16,8 +16,8 @@ rules:
         variables:
           - id
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '[^a-z0-9]'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-6000.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-6000.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - sgpb-willopen
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "<"
@@ -25,8 +25,8 @@ rules:
         variables:
           - sgpb-is-preview
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "1"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-0204.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-0204.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/goanywhere/images/..;'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-28255.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-28255.yaml
@@ -11,8 +11,8 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: /api/v1;v1/users/login/events/subscriptions/validation/condition

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-29028.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-29028.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - url
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: startsWith
           value: http

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-32870.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-32870.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /pages/exec.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - exec_module
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: equals
           value: itop-hub-connector
@@ -26,8 +26,8 @@ rules:
         variables:
           - exec_page
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: equals
           value: launch.php
@@ -36,8 +36,8 @@ rules:
         variables:
           - target
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: equals
           value: inform_after_setup

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-3408.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-3408.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - query
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '__import__('

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-38816.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-38816.yaml
@@ -11,8 +11,8 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: "/static/link/../"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-41713.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-41713.yaml
@@ -5,8 +5,8 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: "/npm-pwg/..;"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-5057.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-5057.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /wp-admin/admin-ajax.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - action
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: equals
           value: edd_download_search
@@ -26,8 +26,8 @@ rules:
         variables:
           - s
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "'"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-51482.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-51482.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /zm/index.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - tid
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '[^0-9]'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-51567.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-51567.yaml
@@ -18,8 +18,8 @@ rules:
     - zones:
       - BODY_ARGS
       transform:
-        - lowercase
         - urldecode
+        - lowercase
       variables:
        - json.statusfile
       match:

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-51977.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-51977.yaml
@@ -5,8 +5,8 @@ rules:
   - zones:
       - URI
     transform:
-      - lowercase
       - urldecode
+      - lowercase
     match:
       type: equals
       value: '/etc/mnt_info.csv'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-6671.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-6671.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - json.statisticalMonitorTable
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: ';'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-7593.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-7593.yaml
@@ -19,8 +19,8 @@ rules:
       variables:
         - section
       transform:
-        - lowercase
         - urldecode
+        - lowercase
       match:
         type: equals
         value: "access management:localusers"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-8911.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-8911.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - action
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: latepoint_route_call
@@ -25,8 +25,8 @@ rules:
         variables:
           - params
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: password_reset_token
@@ -35,8 +35,8 @@ rules:
         variables:
           - params
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: ;

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-8963.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-8963.yaml
@@ -11,8 +11,8 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: "index.php?.php/"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2024-9465.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2024-9465.yaml
@@ -11,8 +11,8 @@ rules:
     - zones:
       - URI
       transform:
-      - lowercase
       - urldecode
+      - lowercase
       match:
         type: contains
         value: "/bin/configurations/parsers/checkpoint/checkpoint.php"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-10353.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-10353.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/melis/meliscmsslider/meliscmssliderdetails/savedetailsform'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-13956.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-13956.yaml
@@ -4,8 +4,8 @@ rules:
   - zones:
       - URI
     transform:
-      - lowercase
       - urldecode
+      - lowercase
     match:
       type: contains
       value: '/wp-json/lp/v1/orders/statistic'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-15503.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-15503.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/fort/trust/version/common/common.jsp'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-24582.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-24582.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/wp-admin/admin-ajax.php'
@@ -15,8 +15,8 @@ rules:
         variables:
           - action
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '^tsml_(info|geocodes)$'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-24786.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-24786.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/api/query'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-27222.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-27222.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - cobrandingImageName
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '../'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-27223.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-27223.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/trufusionportal/getprojectlist'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-28367.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-28367.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /api/betterimagegallery/imagehandler
@@ -16,8 +16,8 @@ rules:
         variables:
           - path
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: ../

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-29306.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-29306.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - id
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '${'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-36604.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-36604.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /misc/

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-40552.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-40552.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/helpdesk/webobjects/helpdesk.woa/wo/'
@@ -15,8 +15,8 @@ rules:
         variables:
           - wopage
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '.+'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-4689.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-4689.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/wp-admin/admin-ajax.php'
@@ -15,8 +15,8 @@ rules:
         variables:
           - action
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'bsa_pro'
@@ -25,8 +25,8 @@ rules:
         variables:
           - a_id
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: "[^0-9]"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-47812.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-47812.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - username
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: ']]'
@@ -25,8 +25,8 @@ rules:
         variables:
           - username
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'io.popen('

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-49132.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-49132.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /locales/locale.json
@@ -16,8 +16,8 @@ rules:
         variables:
           - locale
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '../'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-53693.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-53693.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/-/xaml/'
@@ -16,8 +16,8 @@ rules:
         variables:
           - __parameters
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'addtocache'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-54249.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-54249.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - auth_url
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'http'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-55748.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-55748.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: /bin/(ssx|jsx)/
@@ -16,8 +16,8 @@ rules:
         variables:
           - resource
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '../'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-55749.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-55749.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /webapps/xwiki/web-inf/xwiki.properties

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-56520.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-56520.yaml
@@ -6,16 +6,16 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /console/api/remote-files/http
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '://'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-57819.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-57819.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /admin/ajax.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - module
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "freepbx\\modules\\endpoint\\ajax"
@@ -26,8 +26,8 @@ rules:
         variables:
           - brand
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "'"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-59528.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-59528.yaml
@@ -15,8 +15,8 @@ rules:
         variables:
           - json.inputs.mcpserverconfig
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'function('

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-61678.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-61678.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/admin/config.php'
@@ -15,8 +15,8 @@ rules:
         variables:
           - fwbrand
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '..'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-61882.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-61882.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /oa_html/help/../ieshostedsurvey.jsp
@@ -15,8 +15,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /oa_html/configurator/uiservlet
@@ -25,8 +25,8 @@ rules:
         variables:
           - getuitype
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'ieshostedsurvey.jsp'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-66039.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-66039.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/admin/config.php'
@@ -15,8 +15,8 @@ rules:
         variables:
           - id
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: "[^0-9]"

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2025-8110.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2025-8110.yaml
@@ -20,8 +20,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '../'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-0926.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-0926.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /wp-admin/admin-ajax.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - parameters[template_name]
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: ../

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-1207.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-1207.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: regex
           value: '^/(api/raster/search/)?$'
@@ -16,8 +16,8 @@ rules:
         variables:
           - band
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: libinjectionSQL
 

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-1281.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-1281.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/mifs/c/appstore/fob/'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-1557.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-1557.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: /wp-content/plugins/wp-responsive-images/image_handler.php
@@ -16,8 +16,8 @@ rules:
         variables:
           - src
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: ../

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127-dca-disclosure.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127-dca-disclosure.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
           - normalizepath
         match:
           type: contains

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-20127.yaml
@@ -5,16 +5,16 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/dataservice/smartlicensing/uploadack'
       - zones:
           - FILENAMES
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '..'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-26980.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-26980.yaml
@@ -5,16 +5,16 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/ghost/api/content/'
       - zones:
           - ARGS_NAMES
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'key'
@@ -24,8 +24,8 @@ rules:
           variables:
             - filter
           transform:
-            - lowercase
             - urldecode
+            - lowercase
           match:
             type: contains
             value: '||'
@@ -34,8 +34,8 @@ rules:
           variables:
             - filter
           transform:
-            - lowercase
             - urldecode
+            - lowercase
           match:
             type: contains
             value: '&&'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-61511.yaml
@@ -7,8 +7,8 @@ rules:
         variables:
           - routestring
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: 'ajax/render/pagenav'
@@ -17,8 +17,8 @@ rules:
         variables:
           - pagenav[pagenumber]
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '('

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-72898.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-72898.yaml
@@ -6,8 +6,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/api/session/reset_password'

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2026-9082.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2026-9082.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: '/jsonapi/'
@@ -14,16 +14,16 @@ rules:
         - zones:
             - ARGS_NAMES
           transform:
-            - lowercase
             - urldecode
+            - lowercase
           match:
             type: contains
             value: '||'
         - zones:
             - ARGS_NAMES
           transform:
-            - lowercase
             - urldecode
+            - lowercase
           match:
             type: contains
             value: '`'

--- a/appsec-rules/crowdsecurity/vpatch-WT-2026-0001.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-WT-2026-0001.yaml
@@ -5,8 +5,8 @@ rules:
       - zones:
           - URI
         transform:
-          - lowercase
           - urldecode
+          - lowercase
         match:
           type: contains
           value: "/api/v1/auth/force-reset-password"


### PR DESCRIPTION
Same fix as #1872, applied to the remaining rules: `transform: [lowercase, urldecode]` -> `[urldecode, lowercase]`, 140 occurrences across 82 files. Lowercasing first leaves percent-escapes intact, so they decode to uppercase afterwards and the lowercase match misses.

These rules use zones Coraza pre-decodes (`URI`, `ARGS`, `ARGS_NAMES`, `BODY_ARGS`), so that first decode absorbs one encoding layer and a bypass needs double encoding. Checked against the Coraza engine: for CVE-2025-57819, `?module=%2546ree%2550BX\modules\endpoint\ajax` does not match today and matches after the swap.

Most of these files carry an `## autogenerated on ...` header, so whatever generates them emits the wrong order and should be fixed too, otherwise new rules bring the problem back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kCVups4eddfjUonQomPcs