### PR TITLE
fix(collections): add vpatch-CVE-2025-40552 to appsec-virtual-patching

### DIFF
--- a/collections/crowdsecurity/appsec-virtual-patching.yaml
+++ b/collections/crowdsecurity/appsec-virtual-patching.yaml
@@ -196,6 +196,7 @@ appsec-rules:
 - crowdsecurity/vpatch-CVE-2026-63030
 - crowdsecurity/vpatch-CVE-2026-61511
 - crowdsecurity/vpatch-CVE-2026-72898
+- crowdsecurity/vpatch-CVE-2025-40552
 author: crowdsecurity
 contexts:
 - crowdsecurity/appsec_base


### PR DESCRIPTION
`vpatch-CVE-2025-40552` (SolarWinds Web Help Desk auth bypass) is not in any collection, so nobody installing `appsec-virtual-patching` gets it. Adding it there.

Found while looking at the collection-compliance warning on #1873. The two other rules it flagged, `vpatch-CVE-2022-3254` and `vpatch-CVE-2023-3197`, are WordPress and correctly live in `appsec-wordpress` — the check only looks at `appsec-virtual-patching`, so those are false positives. This one is not WordPress and looks simply missed.

It already has a test in `.appsec-tests/vpatch-CVE-2025-40552/`. Out of 222 appsec rules it and `crs-exclusion-plugin-google-oauth2` are the only two in no collection; I left the exclusion plugin alone since those look standalone by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kCVups4eddfjUonQomPcs