### PR TITLE
Document http-dos-switching-ua internal runtime name

### DIFF
--- a/scenarios/crowdsecurity/http-dos-switching-ua.md
+++ b/scenarios/crowdsecurity/http-dos-switching-ua.md
@@ -5,3 +5,6 @@ This scenario detects specific DoS tools that issue a high number of requests, w
 Directly inspired by some specific DoS tools TTP.
 
 :warning: This scenario might trigger false positives, proper testing is advised :warning:
+
+
+:warning: The Hub item name is `crowdsecurity/http-dos-switching-ua`, but the internal runtime name is `crowdsecurity/http-dos-swithcing-ua`. The misspelling is kept for compatibility. Use the internal name in local configuration, including `cscli simulation enable`. :warning:


### PR DESCRIPTION
Closes #1877

The Hub item is crowdsecurity/http-dos-switching-ua, but the YAML name is crowdsecurity/http-dos-swithcing-ua and that cannot be renamed. Simulation and other local config that uses the Hub name therefore miss the runtime scenario.

This adds a warning on the scenario docs page so people use the internal name for cscli simulation enable and similar config.