### PR TITLE
WAF rule for CVE-2023-54391 (Proxmox VE authentication bypass)

### DIFF
--- a/.appsec-tests/vpatch-CVE-2023-54391/config.yaml
+++ b/.appsec-tests/vpatch-CVE-2023-54391/config.yaml
@@ -1,0 +1,4 @@
+appsec-rules:
+    - ./appsec-rules/crowdsecurity/base-config.yaml
+    - ./appsec-rules/crowdsecurity/vpatch-CVE-2023-54391.yaml
+nuclei_template: vpatch-CVE-2023-54391.yaml

--- a/.appsec-tests/vpatch-CVE-2023-54391/vpatch-CVE-2023-54391.yaml
+++ b/.appsec-tests/vpatch-CVE-2023-54391/vpatch-CVE-2023-54391.yaml
@@ -32,5 +32,5 @@ http:
       condition: and
       dsl:
         - 'status_code_1 == 403'
-        - 'status_code_2 == 405' # legitimate 2FA second step passes through, nginx answers 405 on POST
-        - 'status_code_3 == 405' # plain login without tfa-challenge passes through
+        - 'status_code_2 == 404' # legitimate 2FA second step passes through, nginx answers 404 for the unknown path
+        - 'status_code_3 == 404' # plain login without tfa-challenge passes through

--- a/.appsec-tests/vpatch-CVE-2023-54391/vpatch-CVE-2023-54391.yaml
+++ b/.appsec-tests/vpatch-CVE-2023-54391/vpatch-CVE-2023-54391.yaml
@@ -1,0 +1,36 @@
+id: vpatch-CVE-2023-54391
+info:
+  name: vpatch-CVE-2023-54391
+  author: crowdsec
+  severity: info
+  description: vpatch-CVE-2023-54391 testing
+  tags: appsec-testing
+http:
+  - raw:
+    - |
+      POST /api2/json/access/ticket HTTP/1.1
+      Host: {{Hostname}}
+      Content-Type: application/x-www-form-urlencoded;charset=UTF-8
+
+      username=root%40pam&password=root%40pam&tfa-challenge=NEBUSEC-CHALLENGE
+    - |
+      POST /api2/extjs/access/ticket HTTP/1.1
+      Host: {{Hostname}}
+      Content-Type: application/x-www-form-urlencoded;charset=UTF-8
+
+      username=root%40pam&password=totp%3A123456&tfa-challenge=PVE%3Aroot%40pam%3A0FF00000%3A%3Asig
+    - |
+      POST /api2/json/access/ticket HTTP/1.1
+      Host: {{Hostname}}
+      Content-Type: application/x-www-form-urlencoded;charset=UTF-8
+
+      username=root%40pam&password=root%40pam
+
+    cookie-reuse: true
+    matchers:
+    - type: dsl
+      condition: and
+      dsl:
+        - 'status_code_1 == 403'
+        - 'status_code_2 == 405' # legitimate 2FA second step passes through, nginx answers 405 on POST
+        - 'status_code_3 == 405' # plain login without tfa-challenge passes through

--- a/appsec-rules/crowdsecurity/vpatch-CVE-2023-54391.yaml
+++ b/appsec-rules/crowdsecurity/vpatch-CVE-2023-54391.yaml
@@ -1,0 +1,54 @@
+name: crowdsecurity/vpatch-CVE-2023-54391
+description: 'Detects Proxmox VE authentication bypass via arbitrary tfa-challenge value on the access ticket endpoint (CVE-2023-54391)'
+# A legitimate second-factor step sends a server-issued "PVE:..." ticket as tfa-challenge
+# and a typed response ("totp:123456", "webauthn:...", "yubico:...", "recovery:...") as password.
+# The bypass sends an arbitrary tfa-challenge with a plain password, so we flag either deviation.
+rules:
+  - and:
+      - zones:
+          - METHOD
+        match:
+          type: equals
+          value: POST
+      - zones:
+          - URI
+        transform:
+          - lowercase
+          - urldecode
+        match:
+          type: contains
+          value: '/access/ticket'
+      - or:
+          - zones:
+              - BODY_ARGS
+            variables:
+              - tfa-challenge
+            match:
+              type: regex
+              value: '^(?:[^P]|P[^V]|PV[^E]|PVE[^:]|$)'
+          - and:
+              - zones:
+                  - BODY_ARGS_NAMES
+                match:
+                  type: equals
+                  value: tfa-challenge
+              - zones:
+                  - BODY_ARGS
+                variables:
+                  - password
+                transform:
+                  - lowercase
+                match:
+                  type: regex
+                  value: '^(?:[^a-z]|[a-z]+[^a-z:]|$)'
+labels:
+  type: exploit
+  service: http
+  confidence: 3
+  spoofable: 0
+  behavior: 'http:exploit'
+  label: 'Proxmox VE - Authentication Bypass'
+  classification:
+    - cve.CVE-2023-54391
+    - attack.T1190
+    - cwe.CWE-304

--- a/collections/crowdsecurity/appsec-virtual-patching.yaml
+++ b/collections/crowdsecurity/appsec-virtual-patching.yaml
@@ -196,6 +196,7 @@ appsec-rules:
 - crowdsecurity/vpatch-CVE-2026-63030
 - crowdsecurity/vpatch-CVE-2026-61511
 - crowdsecurity/vpatch-CVE-2026-72898
+- crowdsecurity/vpatch-CVE-2023-54391
 author: crowdsecurity
 contexts:
 - crowdsecurity/appsec_base


### PR DESCRIPTION
Virtual patch for CVE-2023-54391: POST to `/access/ticket` carrying a `tfa-challenge` that is not a server-issued `PVE:` ticket, or paired with a password that is not a typed second-factor response (`totp:`, `webauthn:`, `yubico:`, `recovery:`). Mirrors the alert-context rule crowdsecurity/alert-context-rules@39a8876 and the public nuclei template.
Test covers the exploit request (403) plus a legitimate 2FA second step and a plain login (pass through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVE7PF9rt4CgyE2vRH2nRW