### PR TITLE
sshd-logs: match max-auth-attempts and Disconnecting invalid user

### DIFF
--- a/.tests/sshd-logs/parser.assert
+++ b/.tests/sshd-logs/parser.assert
@@ -1,5 +1,5 @@
 len(results) == 3
-len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 24
+len(results["s00-raw"]["crowdsecurity/syslog-logs"]) == 27
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Success == true
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["logsource"] == "syslog"
 results["s00-raw"]["crowdsecurity/syslog-logs"][0].Evt.Parsed["message"] == "Invalid user pascal from 35.188.49.176 port 53502"
@@ -240,7 +240,37 @@ basename(results["s00-raw"]["crowdsecurity/syslog-logs"][23].Evt.Meta["datasourc
 results["s00-raw"]["crowdsecurity/syslog-logs"][23].Evt.Meta["datasource_type"] == "file"
 results["s00-raw"]["crowdsecurity/syslog-logs"][23].Evt.Meta["machine"] == "myhost"
 results["s00-raw"]["crowdsecurity/syslog-logs"][23].Evt.Whitelisted == false
-len(results["s01-parse"]["crowdsecurity/sshd-logs"]) == 24
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Success == true
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Parsed["logsource"] == "syslog"
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Parsed["message"] == "error: maximum authentication attempts exceeded for invalid user nonexistentuser123 from 127.0.0.1 port 56876 ssh2 [preauth]"
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Parsed["pid"] == "1714650"
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Parsed["program"] == "sshd"
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Parsed["timestamp"] == "Sep  4 23:15:41"
+basename(results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Meta["datasource_path"]) == "sshd-logs.log"
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Meta["datasource_type"] == "file"
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Meta["machine"] == "uptimekuma"
+results["s00-raw"]["crowdsecurity/syslog-logs"][24].Evt.Whitelisted == false
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Success == true
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Parsed["logsource"] == "syslog"
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Parsed["message"] == "Disconnecting invalid user nonexistentuser123 127.0.0.1 port 56876: Too many authentication failures [preauth]"
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Parsed["pid"] == "1714650"
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Parsed["program"] == "sshd"
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Parsed["timestamp"] == "Sep  4 23:15:41"
+basename(results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Meta["datasource_path"]) == "sshd-logs.log"
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Meta["datasource_type"] == "file"
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Meta["machine"] == "uptimekuma"
+results["s00-raw"]["crowdsecurity/syslog-logs"][25].Evt.Whitelisted == false
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Success == true
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Parsed["logsource"] == "syslog"
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Parsed["message"] == "error: maximum authentication attempts exceeded for root from 192.168.1.4 port 56877 ssh2 [preauth]"
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Parsed["pid"] == "1714651"
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Parsed["program"] == "sshd"
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Parsed["timestamp"] == "Sep  4 23:15:42"
+basename(results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Meta["datasource_path"]) == "sshd-logs.log"
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Meta["datasource_type"] == "file"
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Meta["machine"] == "uptimekuma"
+results["s00-raw"]["crowdsecurity/syslog-logs"][26].Evt.Whitelisted == false
+len(results["s01-parse"]["crowdsecurity/sshd-logs"]) == 27
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Success == true
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Evt.Parsed["logsource"] == "syslog"
 results["s01-parse"]["crowdsecurity/sshd-logs"][0].Evt.Parsed["message"] == "Invalid user pascal from 35.188.49.176 port 53502"
@@ -596,4 +626,52 @@ results["s01-parse"]["crowdsecurity/sshd-logs"][23].Evt.Meta["machine"] == "myho
 results["s01-parse"]["crowdsecurity/sshd-logs"][23].Evt.Meta["service"] == "ssh"
 results["s01-parse"]["crowdsecurity/sshd-logs"][23].Evt.Meta["source_ip"] == "192.168.1.1"
 results["s01-parse"]["crowdsecurity/sshd-logs"][23].Evt.Whitelisted == false
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Success == true
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Parsed["logsource"] == "syslog"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Parsed["message"] == "error: maximum authentication attempts exceeded for invalid user nonexistentuser123 from 127.0.0.1 port 56876 ssh2 [preauth]"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Parsed["pid"] == "1714650"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Parsed["program"] == "sshd"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Parsed["sshd_client_ip"] == "127.0.0.1"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Parsed["sshd_invalid_user"] == "nonexistentuser123"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Parsed["timestamp"] == "Sep  4 23:15:41"
+basename(results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Meta["datasource_path"]) == "sshd-logs.log"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Meta["log_type"] == "ssh_failed-auth"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Meta["machine"] == "uptimekuma"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Meta["service"] == "ssh"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Meta["source_ip"] == "127.0.0.1"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Meta["target_user"] == "nonexistentuser123"
+results["s01-parse"]["crowdsecurity/sshd-logs"][24].Evt.Whitelisted == false
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Success == true
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Parsed["logsource"] == "syslog"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Parsed["message"] == "Disconnecting invalid user nonexistentuser123 127.0.0.1 port 56876: Too many authentication failures [preauth]"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Parsed["pid"] == "1714650"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Parsed["program"] == "sshd"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Parsed["sshd_client_ip"] == "127.0.0.1"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Parsed["sshd_invalid_user"] == "nonexistentuser123"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Parsed["timestamp"] == "Sep  4 23:15:41"
+basename(results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Meta["datasource_path"]) == "sshd-logs.log"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Meta["log_type"] == "ssh_failed-auth"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Meta["machine"] == "uptimekuma"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Meta["service"] == "ssh"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Meta["source_ip"] == "127.0.0.1"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Meta["target_user"] == "nonexistentuser123"
+results["s01-parse"]["crowdsecurity/sshd-logs"][25].Evt.Whitelisted == false
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Success == true
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Parsed["logsource"] == "syslog"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Parsed["message"] == "error: maximum authentication attempts exceeded for root from 192.168.1.4 port 56877 ssh2 [preauth]"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Parsed["pid"] == "1714651"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Parsed["program"] == "sshd"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Parsed["sshd_client_ip"] == "192.168.1.4"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Parsed["sshd_invalid_user"] == "root"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Parsed["timestamp"] == "Sep  4 23:15:42"
+basename(results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["datasource_path"]) == "sshd-logs.log"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["datasource_type"] == "file"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["log_type"] == "ssh_failed-auth"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["machine"] == "uptimekuma"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["service"] == "ssh"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["source_ip"] == "192.168.1.4"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["target_user"] == "root"
+results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Whitelisted == false
 len(results["success"][""]) == 0

--- a/.tests/sshd-logs/sshd-logs.log
+++ b/.tests/sshd-logs/sshd-logs.log
@@ -22,3 +22,6 @@ Feb 12 14:10:24 sd-126005 sshd-session[16379]: Invalid user pascal5 from 192.168
 Nov 19 11:28:15 myhost sshd[36648]: Connection closed by 118.27.24.104 port 33594 [preauth]
 Dec 12 14:10:24 myhost sshd[16379]: refused connect from _U2FsdGVkX19P3BCJmFBHhjLza8BcMH06WCUVwttMHpE=_@::ffff:192.168.1.1 (::ffff:192.168.1.1)
 Dec 16 14:10:24 myhost sshd[16379]: refused connect from example.com (192.168.1.1)
+Sep  4 23:15:41 uptimekuma sshd[1714650]: error: maximum authentication attempts exceeded for invalid user nonexistentuser123 from 127.0.0.1 port 56876 ssh2 [preauth]
+Sep  4 23:15:41 uptimekuma sshd[1714650]: Disconnecting invalid user nonexistentuser123 127.0.0.1 port 56876: Too many authentication failures [preauth]
+Sep  4 23:15:42 uptimekuma sshd[1714651]: error: maximum authentication attempts exceeded for root from 192.168.1.4 port 56877 ssh2 [preauth]

--- a/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
+++ b/parsers/s01-parse/crowdsecurity/sshd-logs.yaml
@@ -16,6 +16,13 @@ pattern_syntax:
   SSHD_PREAUTH_AUTHENTICATING_USER: 'Connection (closed|reset) by( (authenticating|invalid) user %{USERNAME:sshd_invalid_user})? %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
   #following: https://github.com/crowdsecurity/crowdsec/issues/1201 - some scanners behave differently and trigger this one
   SSHD_PREAUTH_AUTHENTICATING_USER_ALT: 'Disconnected from (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+ \[preauth\]'
+  # OpenSSH gives up after MaxAuthTries and logs this instead of another
+  # "Invalid user" line, so a brute force that exhausts the limit was dropped
+  # at s01-parse. The "invalid user " part is absent when the account exists.
+  SSHD_MAX_AUTH_ATTEMPTS: 'maximum authentication attempts exceeded for (invalid user )?%{USERNAME:sshd_invalid_user} from %{IP_WORKAROUND:sshd_client_ip}( port \d+)?'
+  # Emitted alongside the above; note "Disconnecting", not the "Disconnected from"
+  # that SSHD_PREAUTH_AUTHENTICATING_USER_ALT matches, and no "from" before the IP.
+  SSHD_DISCONNECTING_INVALID_USER: 'Disconnecting (authenticating|invalid) user %{USERNAME:sshd_invalid_user} %{IP_WORKAROUND:sshd_client_ip} port \d+'
   SSHD_BAD_KEY_NEGOTIATION: 'Unable to negotiate with %{IP_WORKAROUND:sshd_client_ip} port \d+: no matching (host key type|key exchange method|MAC) found.'
   # in case they are blocked by /etc/ssh/sshd_config AllowUsers xx yy
   SSHD_NOT_ALLOWED_USER: 'User %{USERNAME:sshd_invalid_user}? from %{IP_WORKAROUND:sshd_client_ip}( port \d+)? not allowed because not listed in AllowUsers'
@@ -53,6 +60,22 @@ nodes:
   - grok:
       name: "SSHD_BAD_VERSION"
       apply_on: message
+  - grok:
+      name: "SSHD_MAX_AUTH_ATTEMPTS"
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: ssh_failed-auth
+        - meta: target_user
+          expression: "evt.Parsed.sshd_invalid_user"
+  - grok:
+      name: "SSHD_DISCONNECTING_INVALID_USER"
+      apply_on: message
+      statics:
+        - meta: log_type
+          value: ssh_failed-auth
+        - meta: target_user
+          expression: "evt.Parsed.sshd_invalid_user"
   - grok:
       name: "SSHD_INVALID_USER"
       apply_on: message


### PR DESCRIPTION
Closes #1880.

Two OpenSSH messages fell through every `s01-parse` node, so an attacker who exhausted `MaxAuthTries` produced no `ssh_failed-auth` event at all:

```
error: maximum authentication attempts exceeded for invalid user nonexistentuser123 from 127.0.0.1 port 56876 ssh2 [preauth]
Disconnecting invalid user nonexistentuser123 127.0.0.1 port 56876: Too many authentication failures [preauth]
```

Neither is a near miss of an existing pattern. `SSHD_INVALID_USER` wants a capital `Invalid user` and grok is case sensitive, so the lowercase "for invalid user" in the first line never matches it. `SSHD_PREAUTH_AUTHENTICATING_USER_ALT` wants `Disconnected from ... user X IP`, and the second line is `Disconnecting ... user X IP` with no `from`.

Added `SSHD_MAX_AUTH_ATTEMPTS` and `SSHD_DISCONNECTING_INVALID_USER`, both feeding `ssh_failed-auth` with `target_user`, the same as the neighbouring nodes. The first makes `invalid user ` optional, since OpenSSH omits it when the account actually exists, which is the more interesting case: a real account being brute forced was also going unparsed. There is a third log line in the fixture for that.

Verified with `cscli hubtest`, built from crowdsec master since there is no macOS package. The three lines are appended to `.tests/sshd-logs/sshd-logs.log` and `parser.assert` is regenerated by the tool rather than hand written, so the existing 24 entries come back byte for byte identical and only the two counts and the three new blocks change. All three land as `ssh_failed-auth` with the right `source_ip` and `target_user`.

Reverting just the parser and keeping the fixture fails as it should:

    results["s01-parse"]["crowdsecurity/sshd-logs"][26].Evt.Meta["target_user"] = '""'

The other seven sshd tests are green too, `sshd-logs-fp` among them, which is the one I most wanted to see pass since these patterns are deliberately looser than their neighbours: `sshd-logs`, `sshd-logs-fp`, `sshd-invalid-bf`, `sshd-success-logs`, `sshd-refused-conn`, `sshd-bad-keyexchange-bf`, `sshd_banner_exchange` and `opnsense-sshd`.