### PR TITLE
pf/mikrotik-scan-multi_port: set confidence to 0

### DIFF
--- a/scenarios/a1ad/mikrotik-scan-multi_ports.yaml
+++ b/scenarios/a1ad/mikrotik-scan-multi_ports.yaml
@@ -15,6 +15,6 @@ labels:
     - attack.T1018
     - attack.T1046
   spoofable: 2
-  confidence: 1
+  confidence: 0
   label: "MikroTik Port Scanning"
   remediation: true

--- a/scenarios/firewallservices/pf-scan-multi_ports.yaml
+++ b/scenarios/firewallservices/pf-scan-multi_ports.yaml
@@ -9,7 +9,7 @@ leakspeed: 5s
 blackhole: 1m
 labels:
   service: tcp
-  confidence: 1
+  confidence: 0
   spoofable: 3
   classification:
     - attack.T1595.001


### PR DESCRIPTION
Lots of user have misconfigured firewalls that will log response packets as blocked, leading to a ton of false positives, messing up data/ip reputation.

Set the confidence to 0 to ignore those reports when building blocklists.